### PR TITLE
Handle Grandfathering of rate providers from pre-repo days

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,25 @@
+{
+  "semi": false,
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "bracketSpacing": false,
+        "printWidth": 145,
+        "tabWidth": 4,
+        "useTabs": false,
+        "singleQuote": false,
+        "explicitTypes": "always"
+      }
+    },
+    {
+      "files": "*.ts",
+      "options": {
+        "printWidth": 120,
+        "tabWidth": 4,
+        "singleQuote": true,
+        "trailingComma": "all"
+      }
+    }
+  ]
+}

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1,306 +1,304 @@
 {
-  "reviewed": {
-    "arbitrum": {
-      "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
-        "asset": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
-        "name": "AnkrETHRateProvider",
-        "summary": "safe",
-        "review": "./AnkrETHRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
-            "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
-          },
-          {
-            "entrypoint": "0xCb0006B31e6b403fEeEC257A8ABeE0817bEd7eBa",
-            "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
-          }
-        ]
-      },
-      "0xD438f19b1Dd47EbECc5f904d8Fd44583CbFB7c85": {
-        "asset": "0xae48b7C8e096896E32D53F10d0Bf89f82ec7b987",
-        "name": "BalancerRateProvider",
-        "summary": "safe",
-        "review": "./BalancerRateProvider_USDF.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x80e1a981285181686a3951B05dEd454734892a09",
-            "implementationReviewed": "0x038C8535269E4AdC083Ba90388f15788174d7da7"
-          }
-        ]
-      },
-      "0x2bA447d4B823338435057571bF70907F8224BB47": {
-        "asset": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
-        "name": "WrappedUsdPlusRateProvider",
-        "summary": "safe",
-        "review": "./WrappedUsdPlusRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
-            "implementationReviewed": "0xA7E51DF47dcd98F729a80b1C931aAC2b5194f4A0"
-          },
-          {
-            "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-            "implementationReviewed": "0x159f28F598b5C5340D6A902D34eB373D30499660"
-          },
-          {
-            "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
-            "implementationReviewed": "0x763018d8B4c27a6Fb320CD588e2Bc355D0d3049E"
-          },
-          {
-            "entrypoint": "0xa44dF8A8581C2cb536234E6640112fFf932ED2c4",
-            "implementationReviewed": "0x45523bC29D4bCec386f548bDc295DB28483c56E8"
-          }
-        ]
-      },
-      "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51": {
-        "asset": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
-        "name": "PlsRdntassetV2",
-        "summary": "safe",
-        "review": "./PlsRdntassetV2.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
-            "implementationReviewed": "0xF7eB1efc5A3fD02399aC82aa983962280324F9b7"
-          }
-        ]
-      },
-      "0xd4e96ef8eee8678dbff4d535e033ed1a4f7605b7": {
-        "asset": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
-        "name": "RocketBalancerRateProvider",
-        "summary": "safe",
-        "review": "./rETHRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
-            "implementationReviewed": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46"
-          }
-        ]
-      },
-      "0x3bB6861c0Be6673809D55b9D346b6774B634a9D7": {
-        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-        "name": "BalancerAMM",
-        "summary": "safe",
-        "review": "./sweepRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-            "implementationReviewed": "0x19E4F40584824029Fc100c60A74BF41b43EC4976"
-          }
-        ]
-      },
-      "0xf7c5c26B574063e7b098ed74fAd6779e65E3F836": {
-        "asset": "0x5979D7b546E38E414F7E9822514be443A4800529",
-        "name": "ChainlinkRateProvider",
-        "summary": "safe",
-        "review": "./wstethRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0xf25484650484DE3d554fB0b7125e7696efA4ab99": {
-        "asset": "0x2416092f143378750bb29b79eD961ab195CcEea5",
-        "name": "xRenzoDeposit",
-        "summary": "safe",
-        "review": "./ezETHRateProviderArbitrum.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5",
-            "implementationReviewed": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
-          },
-          {
-            "entrypoint": "0xc1036D6bBa2FE24c65823110B348Ee80D3386ACd",
-            "implementationReviewed": "0x5665F1F7ED2dcaD5Dc4CC9B41CA90Bae9DEE1a3A"
-          },
-          {
-            "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
-            "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
-          }
-        ]
-      },
-      "0x87cD462A781c0ca843EAB131Bf368328848bB6fD": {
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./statATokenLMRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x7CFaDFD5645B50bE87d546f42699d863648251ad",
-            "implementationReviewed": "0x4c0633bf70fb2bb984a9eec5d9052bdea451c70a"
-          },
-          {
-            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
-            "implementationReviewed": "0x03e8c5cd5e194659b16456bb43dd5d38886fe541"
-          }
-        ]
-      },
-      "0x48942B49B5bB6f3E1d43c204a3F40a4c5F696ef6": {
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./statATokenLMRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xb165a74407fE1e519d6bCbDeC1Ed3202B35a4140",
-            "implementationReviewed": "0x4c0633bf70fb2bb984a9eec5d9052bdea451c70a"
-          },
-          {
-            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
-            "implementationReviewed": "0x03e8c5cd5e194659b16456bb43dd5d38886fe541"
-          }
-        ]
-      },
-      "0x3A236F67Fce401D87D7215695235e201966576E4": {
-        "name": "MergedAdapterWithoutRoundsSusdeRateProviderV1",
-        "summary": "safe",
-        "review": "./sUSDERateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x3A236F67Fce401D87D7215695235e201966576E4",
-            "implementationReviewed": "0x0e2d75D760b12ac1F2aE84CD2FF9fD13Cb632942"
-          }
-        ]
-      },
-      "0x8aa73EC870DC4a0af6b471937682a8FC3b8A21f8": {
-        "name": "StakePoolRate",
-        "summary": "safe",
-        "review": "./jitoSOLRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xa5f208e072434bC67592E4C49C1B991BA79BCA46",
-            "implementationReviewed": "0x621199f6beB2ba6fbD962E8A52A320EA4F6D4aA3"
-          }
-        ]
-      },
-      "0xd983d5560129475bFC210332422FAdCb4EcD09B0": {
-        "asset": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
-        "name": "cbETH Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Chainlink"],
-        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
-      },
-      "0x2237a270E87F81A30a1980422185f806e4549346": {
-        "asset": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
-        "name": "sfrxETH Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Chainlink"],
-        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
-      },
-      "0x320CFa1a78d37a13C5D1cA5aA51563fF6Bb0f686": {
-        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
-        "name": "sFRAX Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Chainlink"],
-        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
-      },
-      "0x155a25c8C3a9353d47BCDBc3650E19d1aEa13E54": {
-        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
-        "name": "sFRAX Rate Provider Duplicate",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Chainlink"],
-        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
-      }
+  "arbitrum": {
+    "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
+      "asset": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+      "name": "AnkrETHRateProvider",
+      "summary": "safe",
+      "review": "./AnkrETHRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+          "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
+        },
+        {
+          "entrypoint": "0xCb0006B31e6b403fEeEC257A8ABeE0817bEd7eBa",
+          "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
+        }
+      ]
     },
-    "avalanche": {
-      "0xd6Fd021662B83bb1aAbC2006583A62Ad2Efb8d4A": {
-        "asset": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
-        "name": "AnkrETHRateProvider",
-        "summary": "safe",
-        "review": "./AnkrETHRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
-            "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
-          },
-          {
-            "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
-            "implementationReviewed": "0x8ff4fb91c9FFf1F57310dE52D52d033c00523F81"
-          }
-        ]
-      },
-      "0x1bB74eC551cCd9FE416C71F904D64f42079A0a7f": {
-        "asset": "0xa25eaf2906fa1a3a13edac9b9657108af7b703e3",
-        "name": "GGAVAXRateProvider",
-        "summary": "safe",
-        "review": "./GGAVAXRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xA25EaF2906FA1a3a13EdAc9B9657108Af7B703e3",
-            "implementationReviewed": "0xf80Eb498bBfD45f5E2d123DFBdb752677757843E"
-          }
-        ]
-      },
-      "0x13a80aBe608A054059CfB54Ef08809a05Fc07b82": {
-        "asset": "0xf7d9281e8e363584973f946201b82ba72c965d27",
-        "name": "YyAvaxRateProvider",
-        "summary": "safe",
-        "review": "./YyAvaxRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x4fe8C658f268842445Ae8f95D4D6D8Cfd356a8C8",
-            "implementationReviewed": "0x280b6475BE9A67DF23B0EF75D00c876a74Bfc4b7"
-          }
-        ]
-      },
-      "0x709d075147a10495e5c3bBF3dfc0c138F34C6E72": {
-        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-        "name": "BalancerAMM",
-        "summary": "safe",
-        "review": "./sweepRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-            "implementationReviewed": "0x8A7d9967A31fe557041519c131B355176734d907"
-          }
-        ]
-      },
-      "0x5f8147f9e4fB550C5be815C8a20013171eEFB46D": {
-        "asset": "0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE",
-        "name": "sAVAX Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      }
+    "0xD438f19b1Dd47EbECc5f904d8Fd44583CbFB7c85": {
+      "asset": "0xae48b7C8e096896E32D53F10d0Bf89f82ec7b987",
+      "name": "BalancerRateProvider",
+      "summary": "safe",
+      "review": "./BalancerRateProvider_USDF.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x80e1a981285181686a3951B05dEd454734892a09",
+          "implementationReviewed": "0x038C8535269E4AdC083Ba90388f15788174d7da7"
+        }
+      ]
+    },
+    "0x2bA447d4B823338435057571bF70907F8224BB47": {
+      "asset": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
+      "name": "WrappedUsdPlusRateProvider",
+      "summary": "safe",
+      "review": "./WrappedUsdPlusRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
+          "implementationReviewed": "0xA7E51DF47dcd98F729a80b1C931aAC2b5194f4A0"
+        },
+        {
+          "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+          "implementationReviewed": "0x159f28F598b5C5340D6A902D34eB373D30499660"
+        },
+        {
+          "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
+          "implementationReviewed": "0x763018d8B4c27a6Fb320CD588e2Bc355D0d3049E"
+        },
+        {
+          "entrypoint": "0xa44dF8A8581C2cb536234E6640112fFf932ED2c4",
+          "implementationReviewed": "0x45523bC29D4bCec386f548bDc295DB28483c56E8"
+        }
+      ]
+    },
+    "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51": {
+      "asset": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
+      "name": "PlsRdntassetV2",
+      "summary": "safe",
+      "review": "./PlsRdntassetV2.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
+          "implementationReviewed": "0xF7eB1efc5A3fD02399aC82aa983962280324F9b7"
+        }
+      ]
+    },
+    "0xd4e96ef8eee8678dbff4d535e033ed1a4f7605b7": {
+      "asset": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+      "name": "RocketBalancerRateProvider",
+      "summary": "safe",
+      "review": "./rETHRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
+          "implementationReviewed": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46"
+        }
+      ]
+    },
+    "0x3bB6861c0Be6673809D55b9D346b6774B634a9D7": {
+      "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+      "name": "BalancerAMM",
+      "summary": "safe",
+      "review": "./sweepRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+          "implementationReviewed": "0x19E4F40584824029Fc100c60A74BF41b43EC4976"
+        }
+      ]
+    },
+    "0xf7c5c26B574063e7b098ed74fAd6779e65E3F836": {
+      "asset": "0x5979D7b546E38E414F7E9822514be443A4800529",
+      "name": "ChainlinkRateProvider",
+      "summary": "safe",
+      "review": "./wstethRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0xf25484650484DE3d554fB0b7125e7696efA4ab99": {
+      "asset": "0x2416092f143378750bb29b79eD961ab195CcEea5",
+      "name": "xRenzoDeposit",
+      "summary": "safe",
+      "review": "./ezETHRateProviderArbitrum.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5",
+          "implementationReviewed": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
+        },
+        {
+          "entrypoint": "0xc1036D6bBa2FE24c65823110B348Ee80D3386ACd",
+          "implementationReviewed": "0x5665F1F7ED2dcaD5Dc4CC9B41CA90Bae9DEE1a3A"
+        },
+        {
+          "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
+          "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
+        }
+      ]
+    },
+    "0x87cD462A781c0ca843EAB131Bf368328848bB6fD": {
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./statATokenLMRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x7CFaDFD5645B50bE87d546f42699d863648251ad",
+          "implementationReviewed": "0x4c0633bf70fb2bb984a9eec5d9052bdea451c70a"
+        },
+        {
+          "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "implementationReviewed": "0x03e8c5cd5e194659b16456bb43dd5d38886fe541"
+        }
+      ]
+    },
+    "0x48942B49B5bB6f3E1d43c204a3F40a4c5F696ef6": {
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./statATokenLMRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xb165a74407fE1e519d6bCbDeC1Ed3202B35a4140",
+          "implementationReviewed": "0x4c0633bf70fb2bb984a9eec5d9052bdea451c70a"
+        },
+        {
+          "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "implementationReviewed": "0x03e8c5cd5e194659b16456bb43dd5d38886fe541"
+        }
+      ]
+    },
+    "0x3A236F67Fce401D87D7215695235e201966576E4": {
+      "name": "MergedAdapterWithoutRoundsSusdeRateProviderV1",
+      "summary": "safe",
+      "review": "./sUSDERateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x3A236F67Fce401D87D7215695235e201966576E4",
+          "implementationReviewed": "0x0e2d75D760b12ac1F2aE84CD2FF9fD13Cb632942"
+        }
+      ]
+    },
+    "0x8aa73EC870DC4a0af6b471937682a8FC3b8A21f8": {
+      "name": "StakePoolRate",
+      "summary": "safe",
+      "review": "./jitoSOLRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xa5f208e072434bC67592E4C49C1B991BA79BCA46",
+          "implementationReviewed": "0x621199f6beB2ba6fbD962E8A52A320EA4F6D4aA3"
+        }
+      ]
+    },
+    "0xd983d5560129475bFC210332422FAdCb4EcD09B0": {
+      "asset": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
+      "name": "cbETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["chainlink"],
+      "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+    },
+    "0x2237a270E87F81A30a1980422185f806e4549346": {
+      "asset": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
+      "name": "sfrxETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["chainlink"],
+      "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+    },
+    "0x320CFa1a78d37a13C5D1cA5aA51563fF6Bb0f686": {
+      "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
+      "name": "sFRAX Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["chainlink"],
+      "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+    },
+    "0x155a25c8C3a9353d47BCDBc3650E19d1aEa13E54": {
+      "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
+      "name": "sFRAX Rate Provider Duplicate",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["chainlink"],
+      "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+    }
+  },
+  "avalanche": {
+    "0xd6Fd021662B83bb1aAbC2006583A62Ad2Efb8d4A": {
+      "asset": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+      "name": "AnkrETHRateProvider",
+      "summary": "safe",
+      "review": "./AnkrETHRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+          "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
+        },
+        {
+          "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
+          "implementationReviewed": "0x8ff4fb91c9FFf1F57310dE52D52d033c00523F81"
+        }
+      ]
+    },
+    "0x1bB74eC551cCd9FE416C71F904D64f42079A0a7f": {
+      "asset": "0xa25eaf2906fa1a3a13edac9b9657108af7b703e3",
+      "name": "GGAVAXRateProvider",
+      "summary": "safe",
+      "review": "./GGAVAXRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xA25EaF2906FA1a3a13EdAc9B9657108Af7B703e3",
+          "implementationReviewed": "0xf80Eb498bBfD45f5E2d123DFBdb752677757843E"
+        }
+      ]
+    },
+    "0x13a80aBe608A054059CfB54Ef08809a05Fc07b82": {
+      "asset": "0xf7d9281e8e363584973f946201b82ba72c965d27",
+      "name": "YyAvaxRateProvider",
+      "summary": "safe",
+      "review": "./YyAvaxRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x4fe8C658f268842445Ae8f95D4D6D8Cfd356a8C8",
+          "implementationReviewed": "0x280b6475BE9A67DF23B0EF75D00c876a74Bfc4b7"
+        }
+      ]
+    },
+    "0x709d075147a10495e5c3bBF3dfc0c138F34C6E72": {
+      "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+      "name": "BalancerAMM",
+      "summary": "safe",
+      "review": "./sweepRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+          "implementationReviewed": "0x8A7d9967A31fe557041519c131B355176734d907"
+        }
+      ]
+    },
+    "0x5f8147f9e4fB550C5be815C8a20013171eEFB46D": {
+      "asset": "0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE",
+      "name": "sAVAX Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": ""
     },
     "0xD70C8AaC058E6daFe3446F78091325F9E29bcee4": {
       "asset": "0xc3344870d52688874b06d844E0C36cc39FC727F6",
       "name": "ankrAVAX Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     }
   },
@@ -344,7 +342,7 @@
       "name": "cbETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B"
     },
     "0x1Fe586225989Dd88365C2D859670AA0A4379d7e4": {
@@ -352,7 +350,7 @@
       "name": "sfrxETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B"
     },
     "0x5a7A419C59eAAdec8Dc00bc93ac95612e6e154Cf": {
@@ -360,7 +358,7 @@
       "name": "weETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B"
     },
     "0x039f7205C2cBa4535C2575123Ac3D657263892c4": {
@@ -368,7 +366,7 @@
       "name": "rETH RocketPool Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0xe1b1e024f4Bc01Bdde23e891E081b76a1A914ddd": {
@@ -376,7 +374,7 @@
       "name": "wUSD+ Overnight Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     }
   },
@@ -788,7 +786,7 @@
       "name": "RocketBalancerRETHRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x302013E7936a39c358d07A3Df55dc94EC417E3a1": {
@@ -796,7 +794,7 @@
       "name": "sfrxETH ERC4626RateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x00F8e64a8651E3479A0B20F46b1D462Fe29D6aBc": {
@@ -804,7 +802,7 @@
       "name": "AnkrETHRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x7311E4BB8a72e7B300c5B8BDE4de6CdaA822a5b1": {
@@ -812,7 +810,7 @@
       "name": "CbEthRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x3D40f9dd83bd404fA4047c15da494E58C3c1f1ac": {
@@ -820,7 +818,7 @@
       "name": "Stafi RETHRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x3556F710c165090AAE9f98Eb62F5b04ADeF7Eaea": {
@@ -828,7 +826,7 @@
       "name": "jAuraRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0xf951E335afb289353dc249e82926178EaC7DEd78": {
@@ -836,7 +834,7 @@
       "name": "swETH Rate Provider TransparentUpgradeableProxy",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0xdE76434352633349f119bcE523d092743fEF20E9": {
@@ -844,7 +842,7 @@
       "name": "wBETH BinanceBeaconEthRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x12589A727aeFAc3fbE5025F890f1CB97c269BEc2": {
@@ -852,7 +850,7 @@
       "name": "Bitfrost vETHRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x5F0A29e479744DcA0D3d912f87F1a6E3237A55D3": {
@@ -860,8 +858,19 @@
       "name": "unshETHRateProvider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
+    }
+  },
+  "fantom": {
+    "0x629d4c27057915e59dd94bca8d48c6d80735b521": {
+      "asset": "0xd7028092c830b5c8fce061af2e593413ebbc1fc1",
+      "name": "sFTMx Rateprovider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "gnosis": {
@@ -897,7 +906,7 @@
       "name": "wstETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0xE7511f6e5C593007eA8A7F52af4B066333765e03"
     },
     "0xE7511f6e5C593007eA8A7F52af4B066333765e03": {
@@ -905,7 +914,7 @@
       "name": "EURe Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0xE7511f6e5C593007eA8A7F52af4B066333765e03"
     }
   },
@@ -1015,7 +1024,7 @@
       "name": "wstETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
     },
     "0xf752dd899F87a91370C1C8ac1488Aef6be687505": {
@@ -1023,7 +1032,7 @@
       "name": "sfrxETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
     },
     "0x7E13b8b95d887c2326C25e71815F33Ea10A2674e": {
@@ -1031,7 +1040,7 @@
       "name": "sFRAX Rate Provider 2",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
     },
     "0xDe3B7eC86B67B05D312ac8FD935B6F59836F2c41": {
@@ -1039,7 +1048,7 @@
       "name": "sFRAX Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
     },
     "0x7eA8B4e2CaBA854C3dD6bf9c5ebABa143BE7Fe9E": {
@@ -1047,7 +1056,7 @@
       "name": "weETH Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Chainlink"],
+      "warnings": ["chainlink"],
       "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
     },
     "0x658843BB859B7b85cEAb5cF77167e3F0a78dFE7f": {
@@ -1055,7 +1064,7 @@
       "name": "rETH RocketPool Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
       "factory": ""
     },
     "0x97b323fc033323B66159402bcDb9D7B9DC604235": {
@@ -1063,168 +1072,168 @@
       "name": "ankrETH Staking Rate Provider",
       "summary": "safe",
       "review": "",
-      "warnings": ["Legacy"],
+      "warnings": ["legacy"],
+      "factory": ""
+    }
+  },
+  "polygon": {
+    "0x76D8B79Fb9afD4dA89913458C90B6C09676628E2": {
+      "asset": "0x01d1a890D40d890d59795aFCce22F5AdbB511A3a",
+      "name": "RateProvider",
+      "summary": "safe",
+      "review": "./RateProvider_wFRK.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x2cb7285733A30BB08303B917A7a519C88146C6Eb",
+          "implementationReviewed": "0xEdb20e3cD8C7c149Ea57fe470fb9685c4b1B8703"
+        },
+        {
+          "entrypoint": "0x4dBA794671B891D2Ee2E3E7eA9E993026219941C",
+          "implementationReviewed": "0x7714fcFe0d9C4726F6C1E3B1275C2951B9B54F65"
+        },
+        {
+          "entrypoint": "0x0aC2E3Cd1E9b2DA91972d2363e76B5A0cE514e73",
+          "implementationReviewed": "0x41d4D26F70951a2134DC862ea6248fFBE2a516bb"
+        },
+        {
+          "entrypoint": "0x173EB1d561CcEFd8e83a3741483a8Bd76dF827Ef",
+          "implementationReviewed": "0x72e923047245D2B58D87f311a2b5b487620EE60A"
+        }
+      ]
+    },
+    "0x7d10050F608c8EFFf118eDd1416D82a0EF2d7531": {
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./statATokenLMRateProvider.md",
+      "warnings": [""],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x2dCa80061632f3F87c9cA28364d1d0c30cD79a19",
+          "implementationReviewed": "0x6a7192c55e9298874e49675a63d5ebb11ed99a66"
+        },
+        {
+          "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "implementationReviewed": "0x1ed647b250e5b6d71dc7b25806f44c33f5658f71"
+        }
+      ]
+    },
+    "0x9977a61a6aa950044d4dcD8aA0cAb76F84ea5aCd": {
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./statATokenLMRateProvider.md",
+      "warnings": [""],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x87A1fdc4C726c459f597282be639a045062c0E46",
+          "implementationReviewed": "0x6a7192c55e9298874e49675a63d5ebb11ed99a66"
+        },
+        {
+          "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "implementationReviewed": "0x1ed647b250e5b6d71dc7b25806f44c33f5658f71"
+        }
+      ]
+    },
+    "0x8c1944E305c590FaDAf0aDe4f737f5f95a4971B6": {
+      "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+      "name": "wstETH / ETH Rate Provider",
+      "summary": "unsafe",
+      "review": "Do not use, wrong pricing pair",
+      "warnings": ["chainlink"],
+      "factory": "0xa3b370092aeb56770B23315252aB5E16DAcBF62B"
+    },
+    "0x693A9Aca2f7b699BBd3d55d980Ac8a5D7a66868B": {
+      "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+      "name": "wstETH-stETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["chainlink"],
+      "factory": "0xa3b370092aeb56770B23315252aB5E16DAcBF62B"
+    },
+    "0xeE652bbF72689AA59F0B8F981c9c90e2A8Af8d8f": {
+      "asset": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+      "name": "MaticX Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
       "factory": ""
     },
-    "polygon": {
-      "0x76D8B79Fb9afD4dA89913458C90B6C09676628E2": {
-        "asset": "0x01d1a890D40d890d59795aFCce22F5AdbB511A3a",
-        "name": "RateProvider",
-        "summary": "safe",
-        "review": "./RateProvider_wFRK.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x2cb7285733A30BB08303B917A7a519C88146C6Eb",
-            "implementationReviewed": "0xEdb20e3cD8C7c149Ea57fe470fb9685c4b1B8703"
-          },
-          {
-            "entrypoint": "0x4dBA794671B891D2Ee2E3E7eA9E993026219941C",
-            "implementationReviewed": "0x7714fcFe0d9C4726F6C1E3B1275C2951B9B54F65"
-          },
-          {
-            "entrypoint": "0x0aC2E3Cd1E9b2DA91972d2363e76B5A0cE514e73",
-            "implementationReviewed": "0x41d4D26F70951a2134DC862ea6248fFBE2a516bb"
-          },
-          {
-            "entrypoint": "0x173EB1d561CcEFd8e83a3741483a8Bd76dF827Ef",
-            "implementationReviewed": "0x72e923047245D2B58D87f311a2b5b487620EE60A"
-          }
-        ]
-      },
-      "0x7d10050F608c8EFFf118eDd1416D82a0EF2d7531": {
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./statATokenLMRateProvider.md",
-        "warnings": [""],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x2dCa80061632f3F87c9cA28364d1d0c30cD79a19",
-            "implementationReviewed": "0x6a7192c55e9298874e49675a63d5ebb11ed99a66"
-          },
-          {
-            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
-            "implementationReviewed": "0x1ed647b250e5b6d71dc7b25806f44c33f5658f71"
-          }
-        ]
-      },
-      "0x9977a61a6aa950044d4dcD8aA0cAb76F84ea5aCd": {
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./statATokenLMRateProvider.md",
-        "warnings": [""],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x87A1fdc4C726c459f597282be639a045062c0E46",
-            "implementationReviewed": "0x6a7192c55e9298874e49675a63d5ebb11ed99a66"
-          },
-          {
-            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
-            "implementationReviewed": "0x1ed647b250e5b6d71dc7b25806f44c33f5658f71"
-          }
-        ]
-      },
-      "0x8c1944E305c590FaDAf0aDe4f737f5f95a4971B6": {
-        "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
-        "name": "wstETH / ETH Rate Provider",
-        "summary": "unsafe",
-        "review": "Do not use, wrong pricing pair",
-        "warnings": ["Chainlink"],
-        "factory": "0xa3b370092aeb56770B23315252aB5E16DAcBF62B"
-      },
-      "0x693A9Aca2f7b699BBd3d55d980Ac8a5D7a66868B": {
-        "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
-        "name": "wstETH-stETH Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Chainlink"],
-        "factory": "0xa3b370092aeb56770B23315252aB5E16DAcBF62B"
-      },
-      "0xeE652bbF72689AA59F0B8F981c9c90e2A8Af8d8f": {
-        "asset": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
-        "name": "MaticX Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      },
-      "0xdEd6C522d803E35f65318a9a4d7333a22d582199": {
-        "asset": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
-        "name": "stMATIC Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      },
-      "0x87393BE8ac323F2E63520A6184e5A8A9CC9fC051": {
-        "asset": "0xFcBB00dF1d663eeE58123946A30AB2138bF9eb2A",
-        "name": "csMATIC Clay Stack Tunnel Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      },
-      "0x737b6ea575AD54e0c4F45c7A36Ad8c0e730aAD74": {
-        "asset": "0xAF0D9D65fC54de245cdA37af3d18cbEc860A4D4b",
-        "name": "wUSDR Rate Provider",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      }
+    "0xdEd6C522d803E35f65318a9a4d7333a22d582199": {
+      "asset": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+      "name": "stMATIC Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": ""
     },
-    "zkevm": {
-      "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
-        "asset": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
-        "name": "AnkrETHRateProvider",
-        "summary": "safe",
-        "review": "./AnkrETHRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
-            "implementationReviewed": "0x8d98D8ec0D930078a083C7be54430D2093d3D4aB"
-          },
-          {
-            "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
-            "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
-          }
-        ]
-      },
-      "0x4186BFC76E2E237523CBC30FD220FE055156b41F": {
-        "asset": "0x8C7D118B5c47a5BCBD47cc51789558B98dAD17c5",
-        "name": "RSETHRateReceiver",
-        "summary": "safe",
-        "review": "./rsEthRateProviderPolygonZKEVM.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x4186BFC76E2E237523CBC30FD220FE055156b41F",
-            "implementationReviewed": "0x4186BFC76E2E237523CBC30FD220FE055156b41F"
-          }
-        ]
-      },
-      "0x60b39BEC6AF8206d1E6E8DFC63ceA214A506D6c3": {
-        "asset": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
-        "name": "rETH Rate Receiver",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      },
-      "0x00346D2Fd4B2Dc3468fA38B857409BC99f832ef8": {
-        "asset": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
-        "name": "wstETH Rate Receiver",
-        "summary": "safe",
-        "review": "",
-        "warnings": ["Legacy"],
-        "factory": ""
-      }
+    "0x87393BE8ac323F2E63520A6184e5A8A9CC9fC051": {
+      "asset": "0xFcBB00dF1d663eeE58123946A30AB2138bF9eb2A",
+      "name": "csMATIC Clay Stack Tunnel Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": ""
+    },
+    "0x737b6ea575AD54e0c4F45c7A36Ad8c0e730aAD74": {
+      "asset": "0xAF0D9D65fC54de245cdA37af3d18cbEc860A4D4b",
+      "name": "wUSDR Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": ""
+    }
+  },
+  "zkevm": {
+    "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
+      "asset": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+      "name": "AnkrETHRateProvider",
+      "summary": "safe",
+      "review": "./AnkrETHRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+          "implementationReviewed": "0x8d98D8ec0D930078a083C7be54430D2093d3D4aB"
+        },
+        {
+          "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
+          "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
+        }
+      ]
+    },
+    "0x4186BFC76E2E237523CBC30FD220FE055156b41F": {
+      "asset": "0x8C7D118B5c47a5BCBD47cc51789558B98dAD17c5",
+      "name": "RSETHRateReceiver",
+      "summary": "safe",
+      "review": "./rsEthRateProviderPolygonZKEVM.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x4186BFC76E2E237523CBC30FD220FE055156b41F",
+          "implementationReviewed": "0x4186BFC76E2E237523CBC30FD220FE055156b41F"
+        }
+      ]
+    },
+    "0x60b39BEC6AF8206d1E6E8DFC63ceA214A506D6c3": {
+      "asset": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
+      "name": "rETH Rate Receiver",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": ""
+    },
+    "0x00346D2Fd4B2Dc3468fA38B857409BC99f832ef8": {
+      "asset": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
+      "name": "wstETH Rate Receiver",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["legacy"],
+      "factory": ""
     }
   }
 }

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -2,7 +2,7 @@
   "reviewed": {
     "arbitrum": {
       "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
-        "asset":"0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+        "asset": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
         "name": "AnkrETHRateProvider",
         "summary": "safe",
         "review": "./AnkrETHRateProvider.md",
@@ -703,5 +703,172 @@
         ]
       }
     }
+  },
+  "chainlink": {
+    "arbitrum": {
+      "0xd983d5560129475bFC210332422FAdCb4EcD09B0": {
+        "asset": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
+        "name": "cbETH Rate Provider"
+      },
+      "0x2237a270E87F81A30a1980422185f806e4549346": {
+        "asset": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
+        "name": "sfrxETH Rate Provider"
+      },
+      "0x320CFa1a78d37a13C5D1cA5aA51563fF6Bb0f686": {
+        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
+        "name": "sFRAX Rate Provider"
+      },
+      "0x155a25c8C3a9353d47BCDBc3650E19d1aEa13E54": {
+        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
+        "name": "sFRAX Rate Provider Duplicate"
+      }
+    },
+      "avalanche": {},
+      "base": {
+        "0x3786a6CAAB433f5dfE56503207DF31DF87C5b5C1": {
+          "asset": "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
+          "name": "cbETH Rate Provider"
+        }
+      },
+      "ethereum": {},
+      "gnosis": {
+        "0x09f9611FE9d24c6A518f656E925e3628A2ECDE3b": {
+          "asset": "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
+          "name": "wstETH Rate Provider"
+        },
+        "0xE7511f6e5C593007eA8A7F52af4B066333765e03": {
+          "asset": "0xcB444e90D8198415266c6a2724b7900fb12FC56E",
+          "name": "EURe Rate Provider"
+        }
+      },
+      "optimism": {
+        "0x9aa3cd420f830E049e2b223D0b07D8c809C94d15": {
+          "asset": "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
+          "name": "wstETH Rate Provider"
+        },
+        "0xf752dd899F87a91370C1C8ac1488Aef6be687505": {
+          "asset": "0x484c2D6e3cDd945a8B2DF735e079178C1036578c",
+          "name": "sfrxETH Rate Provider"
+        },
+        "0xDe3B7eC86B67B05D312ac8FD935B6F59836F2c41": {
+          "asset": "0x2Dd1B4D4548aCCeA497050619965f91f78b3b532",
+          "name": "sFRAX Rate Provider"
+        }
+      }, 
+      "polygon": {
+        "0x8c1944E305c590FaDAf0aDe4f737f5f95a4971B6": {
+          "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+          "name": "wstETH Rate Provider"
+        },
+        "0x693A9Aca2f7b699BBd3d55d980Ac8a5D7a66868B": {
+          "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+          "name": "wstETH Rate Provider Duplicate"
+        }
+      },
+      "zkevm": {}
+  },
+  "legacy": {
+    "arbitrum": {},
+      "avalanche": {
+        "0x5f8147f9e4fB550C5be815C8a20013171eEFB46D": {
+          "asset": "0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE",
+          "name": "sAVAX Rate Provider"
+        },
+        "0xD70C8AaC058E6daFe3446F78091325F9E29bcee4": {
+          "asset": "0xc3344870d52688874b06d844E0C36cc39FC727F6",
+          "name": "ankrAVAX Rate Provider"
+        }
+      },
+      "base": {
+        "0x039f7205C2cBa4535C2575123Ac3D657263892c4": {
+          "asset": "0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c",
+          "name": "rETH RocketPool Rate Provider"
+        },
+        "0xe1b1e024f4Bc01Bdde23e891E081b76a1A914ddd": {
+          "asset": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
+          "name": "wUSD+ Overnight Rate Provider"
+        }
+      },
+      "ethereum": {
+        "0x1a8F81c256aee9C640e14bB0453ce247ea0DFE6F": {
+          "asset": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+          "name": "RocketBalancerRETHRateProvider"
+        },
+        "0x302013E7936a39c358d07A3Df55dc94EC417E3a1": {
+          "asset": "0xac3E018457B222d93114458476f3E3416Abbe38F",
+          "name": "sfrxETH ERC4626RateProvider"
+        },
+        "0x00F8e64a8651E3479A0B20F46b1D462Fe29D6aBc": {
+          "asset": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
+          "name": "AnkrETHRateProvider"
+        },
+        "0x7311E4BB8a72e7B300c5B8BDE4de6CdaA822a5b1": {
+          "asset": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+          "name": "CbEthRateProvider"
+        },
+        "0x3D40f9dd83bd404fA4047c15da494E58C3c1f1ac": {
+          "asset": "0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593",
+          "name": "Stafi RETHRateProvider"
+        },
+        "0x3556F710c165090AAE9f98Eb62F5b04ADeF7Eaea": {
+          "asset": "0x198d7387Fa97A73F05b8578CdEFf8F2A1f34Cd1F",
+          "name": "jAuraRateProvider"
+        },
+        "0xf951E335afb289353dc249e82926178EaC7DEd78": {
+          "asset": "0xf951E335afb289353dc249e82926178EaC7DEd78",
+          "name": "swETH Rate Provider TransparentUpgradeableProxy"
+        },
+        "0xdE76434352633349f119bcE523d092743fEF20E9": {
+          "asset": "0xa2E3356610840701BDf5611a53974510Ae27E2e1",
+          "name": "wBETH BinanceBeaconEthRateProvider"
+        },
+        "0x12589A727aeFAc3fbE5025F890f1CB97c269BEc2": {
+          "asset": "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F",
+          "name": "Bitfrost vETHRateProvider"
+        },
+        "0x5F0A29e479744DcA0D3d912f87F1a6E3237A55D3": {
+          "asset": "0x0Ae38f7E10A43B5b2fB064B42a2f4514cbA909ef",
+          "name": "unshETHRateProvider"
+        }
+      },
+      "gnosis": {},
+      "optimism": {
+        "0x658843BB859B7b85cEAb5cF77167e3F0a78dFE7f": {
+          "asset": "0x9Bcef72be871e61ED4fBbc7630889beE758eb81D",
+          "name": "rETH RocketPool Rate Provider"
+        },
+        "0x97b323fc033323B66159402bcDb9D7B9DC604235": {
+          "asset": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+          "name": "ankrETH Staking Rate Provider"
+        }
+      },
+      "polygon": {
+        "0xeE652bbF72689AA59F0B8F981c9c90e2A8Af8d8f": {
+          "asset": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+          "name": "MaticX Rate Provider"
+        },
+        "0xdEd6C522d803E35f65318a9a4d7333a22d582199": {
+          "asset": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+          "name": "stMATIC Rate Provider"
+        },
+        "0x87393BE8ac323F2E63520A6184e5A8A9CC9fC051": {
+          "asset": "0xFcBB00dF1d663eeE58123946A30AB2138bF9eb2A",
+          "name": "csMATIC Clay Stack Tunnel Rate Provider"
+        },
+        "0x737b6ea575AD54e0c4F45c7A36Ad8c0e730aAD74": {
+          "asset": "0xAF0D9D65fC54de245cdA37af3d18cbEc860A4D4b",
+          "name": "wUSDR Rate Provider"
+        }
+      },
+      "zkevm": { 
+        "0x60b39BEC6AF8206d1E6E8DFC63ceA214A506D6c3": {
+          "asset": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
+          "name": "rETH Rate Receiver"
+        },
+        "0x00346D2Fd4B2Dc3468fA38B857409BC99f832ef8": {
+          "asset": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
+          "name": "wstETH Rate Receiver"
+        }
+      }
   }
 }

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1,704 +1,707 @@
 {
+  "reviewed": {
     "arbitrum": {
-        "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
-            "name": "AnkrETHRateProvider",
-            "summary": "safe",
-            "review": "./AnkrETHRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
-                    "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
-                },
-                {
-                    "entrypoint": "0xCb0006B31e6b403fEeEC257A8ABeE0817bEd7eBa",
-                    "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
-                }
-            ]
-        },
-        "0xD438f19b1Dd47EbECc5f904d8Fd44583CbFB7c85": {
-            "name": "BalancerRateProvider",
-            "summary": "safe",
-            "review": "./BalancerRateProvider_USDF.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x80e1a981285181686a3951B05dEd454734892a09",
-                    "implementationReviewed": "0x038C8535269E4AdC083Ba90388f15788174d7da7"
-                }
-            ]
-        },
-        "0x2bA447d4B823338435057571bF70907F8224BB47": {
-            "name": "WrappedUsdPlusRateProvider",
-            "summary": "safe",
-            "review": "./WrappedUsdPlusRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
-                    "implementationReviewed": "0xA7E51DF47dcd98F729a80b1C931aAC2b5194f4A0"
-                },
-                {
-                    "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-                    "implementationReviewed": "0x159f28F598b5C5340D6A902D34eB373D30499660"
-                },
-                {
-                    "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
-                    "implementationReviewed": "0x763018d8B4c27a6Fb320CD588e2Bc355D0d3049E"
-                },
-                {
-                    "entrypoint": "0xa44dF8A8581C2cb536234E6640112fFf932ED2c4",
-                    "implementationReviewed": "0x45523bC29D4bCec386f548bDc295DB28483c56E8"
-                }
-            ]
-        },
-        "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51": {
-            "name": "PlsRdntTokenV2",
-            "summary": "safe",
-            "review": "./PlsRdntTokenV2.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
-                    "implementationReviewed": "0xF7eB1efc5A3fD02399aC82aa983962280324F9b7"
-                }
-            ]
-        },
-        "0xd4e96ef8eee8678dbff4d535e033ed1a4f7605b7": {
-            "name": "RocketBalancerRateProvider",
-            "summary": "safe",
-            "review": "./rETHRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
-                    "implementationReviewed": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46"
-                }
-            ]
-        },
-        "0x3bB6861c0Be6673809D55b9D346b6774B634a9D7": {
-            "name": "BalancerAMM",
-            "summary": "safe",
-            "review": "./sweepRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-                    "implementationReviewed": "0x19E4F40584824029Fc100c60A74BF41b43EC4976"
-                }
-            ]
-        },
-        "0xf7c5c26B574063e7b098ed74fAd6779e65E3F836": {
-            "name": "ChainlinkRateProvider",
-            "summary": "safe",
-            "review": "./wstethRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0xf25484650484DE3d554fB0b7125e7696efA4ab99": {
-            "name": "xRenzoDeposit",
-            "summary": "safe",
-            "review": "./ezETHRateProviderArbitrum.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5",
-                    "implementationReviewed": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
-                },
-                {
-                    "entrypoint": "0xc1036D6bBa2FE24c65823110B348Ee80D3386ACd",
-                    "implementationReviewed": "0x5665F1F7ED2dcaD5Dc4CC9B41CA90Bae9DEE1a3A"
-                },
-                {
-                    "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
-                    "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
-                }
-            ]
-        }
+      "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
+        "asset":"0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+        "name": "AnkrETHRateProvider",
+        "summary": "safe",
+        "review": "./AnkrETHRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+            "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
+          },
+          {
+            "entrypoint": "0xCb0006B31e6b403fEeEC257A8ABeE0817bEd7eBa",
+            "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
+          }
+        ]
+      },
+      "0xD438f19b1Dd47EbECc5f904d8Fd44583CbFB7c85": {
+        "asset": "0xae48b7C8e096896E32D53F10d0Bf89f82ec7b987",
+        "name": "BalancerRateProvider",
+        "summary": "safe",
+        "review": "./BalancerRateProvider_USDF.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x80e1a981285181686a3951B05dEd454734892a09",
+            "implementationReviewed": "0x038C8535269E4AdC083Ba90388f15788174d7da7"
+          }
+        ]
+      },
+      "0x2bA447d4B823338435057571bF70907F8224BB47": {
+        "asset": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
+        "name": "WrappedUsdPlusRateProvider",
+        "summary": "safe",
+        "review": "./WrappedUsdPlusRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xB86fb1047A955C0186c77ff6263819b37B32440D",
+            "implementationReviewed": "0xA7E51DF47dcd98F729a80b1C931aAC2b5194f4A0"
+          },
+          {
+            "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+            "implementationReviewed": "0x159f28F598b5C5340D6A902D34eB373D30499660"
+          },
+          {
+            "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
+            "implementationReviewed": "0x763018d8B4c27a6Fb320CD588e2Bc355D0d3049E"
+          },
+          {
+            "entrypoint": "0xa44dF8A8581C2cb536234E6640112fFf932ED2c4",
+            "implementationReviewed": "0x45523bC29D4bCec386f548bDc295DB28483c56E8"
+          }
+        ]
+      },
+      "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51": {
+        "asset": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
+        "name": "PlsRdntassetV2",
+        "summary": "safe",
+        "review": "./PlsRdntassetV2.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x6dbF2155B0636cb3fD5359FCcEFB8a2c02B6cb51",
+            "implementationReviewed": "0xF7eB1efc5A3fD02399aC82aa983962280324F9b7"
+          }
+        ]
+      },
+      "0xd4e96ef8eee8678dbff4d535e033ed1a4f7605b7": {
+        "asset": "0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8",
+        "name": "RocketBalancerRateProvider",
+        "summary": "safe",
+        "review": "./rETHRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46",
+            "implementationReviewed": "0x1d8f8f00cfa6758d7bE78336684788Fb0ee0Fa46"
+          }
+        ]
+      },
+      "0x3bB6861c0Be6673809D55b9D346b6774B634a9D7": {
+        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+        "name": "BalancerAMM",
+        "summary": "safe",
+        "review": "./sweepRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+            "implementationReviewed": "0x19E4F40584824029Fc100c60A74BF41b43EC4976"
+          }
+        ]
+      },
+      "0xf7c5c26B574063e7b098ed74fAd6779e65E3F836": {
+        "asset": "0x5979D7b546E38E414F7E9822514be443A4800529",
+        "name": "ChainlinkRateProvider",
+        "summary": "safe",
+        "review": "./wstethRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0xf25484650484DE3d554fB0b7125e7696efA4ab99": {
+        "asset": "0x2416092f143378750bb29b79eD961ab195CcEea5",
+        "name": "xRenzoDeposit",
+        "summary": "safe",
+        "review": "./ezETHRateProviderArbitrum.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x0e60fd361fF5b90088e1782e6b21A7D177d462C5",
+            "implementationReviewed": "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
+          },
+          {
+            "entrypoint": "0xc1036D6bBa2FE24c65823110B348Ee80D3386ACd",
+            "implementationReviewed": "0x5665F1F7ED2dcaD5Dc4CC9B41CA90Bae9DEE1a3A"
+          },
+          {
+            "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
+            "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
+          }
+        ]
+      }
     },
     "avalanche": {
-        "0xd6Fd021662B83bb1aAbC2006583A62Ad2Efb8d4A": {
-            "name": "AnkrETHRateProvider",
-            "summary": "safe",
-            "review": "./AnkrETHRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
-                    "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
-                },
-                {
-                    "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
-                    "implementationReviewed": "0x8ff4fb91c9FFf1F57310dE52D52d033c00523F81"
-                }
-            ]
-        },
-        "0x1bB74eC551cCd9FE416C71F904D64f42079A0a7f": {
-            "name": "GGAVAXRateProvider",
-            "summary": "safe",
-            "review": "./GGAVAXRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xA25EaF2906FA1a3a13EdAc9B9657108Af7B703e3",
-                    "implementationReviewed": "0xf80Eb498bBfD45f5E2d123DFBdb752677757843E"
-                }
-            ]
-        },
-        "0x13a80aBe608A054059CfB54Ef08809a05Fc07b82": {
-            "name": "YyAvaxRateProvider",
-            "summary": "safe",
-            "review": "./YyAvaxRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x4fe8C658f268842445Ae8f95D4D6D8Cfd356a8C8",
-                    "implementationReviewed": "0x280b6475BE9A67DF23B0EF75D00c876a74Bfc4b7"
-                }
-            ]
-        },
-        "0x709d075147a10495e5c3bBF3dfc0c138F34C6E72": {
-            "name": "BalancerAMM",
-            "summary": "safe",
-            "review": "./sweepRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-                    "implementationReviewed": "0x8A7d9967A31fe557041519c131B355176734d907"
-                }
-            ]
-        }
+      "0xd6Fd021662B83bb1aAbC2006583A62Ad2Efb8d4A": {
+        "asset": "0x12d8ce035c5de3ce39b1fdd4c1d5a745eaba3b8c",
+        "name": "AnkrETHRateProvider",
+        "summary": "safe",
+        "review": "./AnkrETHRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+            "implementationReviewed": "0x4d8798836b630025C5c98FEbd10a90B3D7596777"
+          },
+          {
+            "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
+            "implementationReviewed": "0x8ff4fb91c9FFf1F57310dE52D52d033c00523F81"
+          }
+        ]
+      },
+      "0x1bB74eC551cCd9FE416C71F904D64f42079A0a7f": {
+        "asset": "0xa25eaf2906fa1a3a13edac9b9657108af7b703e3",
+        "name": "GGAVAXRateProvider",
+        "summary": "safe",
+        "review": "./GGAVAXRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xA25EaF2906FA1a3a13EdAc9B9657108Af7B703e3",
+            "implementationReviewed": "0xf80Eb498bBfD45f5E2d123DFBdb752677757843E"
+          }
+        ]
+      },
+      "0x13a80aBe608A054059CfB54Ef08809a05Fc07b82": {
+        "asset": "0xf7d9281e8e363584973f946201b82ba72c965d27",
+        "name": "YyAvaxRateProvider",
+        "summary": "safe",
+        "review": "./YyAvaxRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x4fe8C658f268842445Ae8f95D4D6D8Cfd356a8C8",
+            "implementationReviewed": "0x280b6475BE9A67DF23B0EF75D00c876a74Bfc4b7"
+          }
+        ]
+      },
+      "0x709d075147a10495e5c3bBF3dfc0c138F34C6E72": {
+        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+        "name": "BalancerAMM",
+        "summary": "safe",
+        "review": "./sweepRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+            "implementationReviewed": "0x8A7d9967A31fe557041519c131B355176734d907"
+          }
+        ]
+      }
     },
     "base": {
-        "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
-            "name": "WrappedUsdPlusRateProvider",
-            "summary": "safe",
-            "review": "./WrappedUsdPlusRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
-                    "implementationReviewed": "0xE3434045a3bE5376e8d3Cf841981835996561f80"
-                },
-                {
-                    "entrypoint": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
-                    "implementationReviewed": "0x441Df98011aD427C5692418999ba2150e6d84277"
-                },
-                {
-                    "entrypoint": "0x7cb1B38591021309C64f451859d79312d8Ca2789",
-                    "implementationReviewed": "0x083f016e9928a3eaa3aca0ff9f4e4ded5db3b4b7"
-                },
-                {
-                    "entrypoint": "0x8ab9012D1BfF1b62c2ad82AE0106593371e6b247",
-                    "implementationReviewed": "0x292F13d4BfD6f6aE0Bf8Be981bcC44eC4850e5E9"
-                }
-            ]
-        }
+      "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
+        "asset": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
+        "name": "WrappedUsdPlusRateProvider",
+        "summary": "safe",
+        "review": "./WrappedUsdPlusRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
+            "implementationReviewed": "0xE3434045a3bE5376e8d3Cf841981835996561f80"
+          },
+          {
+            "entrypoint": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
+            "implementationReviewed": "0x441Df98011aD427C5692418999ba2150e6d84277"
+          },
+          {
+            "entrypoint": "0x7cb1B38591021309C64f451859d79312d8Ca2789",
+            "implementationReviewed": "0x083f016e9928a3eaa3aca0ff9f4e4ded5db3b4b7"
+          },
+          {
+            "entrypoint": "0x8ab9012D1BfF1b62c2ad82AE0106593371e6b247",
+            "implementationReviewed": "0x292F13d4BfD6f6aE0Bf8Be981bcC44eC4850e5E9"
+          }
+        ]
+      }
     },
     "ethereum": {
-        "0x2c3b8c5e98A6e89AAAF21Deebf5FF9d08c4A9FF7": {
-            "name": "BalancerRateProxy",
-            "summary": "safe",
-            "review": "./BalancerRateProxy_uniETH.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x4beFa2aA9c305238AA3E0b5D17eB20C045269E9d",
-                    "implementationReviewed": "0x9Ba573D531b45521a4409f3D3e1bC0d7dfF7C757"
-                }
-            ]
-        },
-        "0xAAE054B9b822554dd1D9d1F48f892B4585D3bbf0": {
-            "name": "ETHxRateProvider",
-            "summary": "safe",
-            "review": "./ETHxRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xcf5EA1b38380f6aF39068375516Daf40Ed70D299",
-                    "implementationReviewed": "0x9dceaeB1C035C1427E64E6c6fEC61F816e0d0FF5"
-                }
-            ]
-        },
-        "0xA6aeD7922366611953546014A3f9e93f058756a2": {
-            "name": "QueenRateProvider",
-            "summary": "safe",
-            "review": "./QueenRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0x67560A970FFaB46D65cB520dD3C2fF4E684f29c2": {
-            "name": "TBYRateProvider",
-            "summary": "safe",
-            "review": "./TBYRateProvider.md",
-            "warnings": [],
-            "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
-            "upgradeableComponents": []
-        },
-        "0xDceC4350d189Ea7e1DD2C9BDa63cB0e0Ae34b81F": {
-            "name": "TBYRateProvider",
-            "summary": "safe",
-            "review": "./TBYRateProvider.md",
-            "warnings": [],
-            "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
-            "upgradeableComponents": []
-        },
-        "0xc7177B6E18c1Abd725F5b75792e5F7A3bA5DBC2c": {
-            "name": "SavingsDAIRateProvider",
-            "summary": "safe",
-            "review": "./SavingsDAIRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0xd8689E8740C23d73136744817347fd6aC464E842": {
-            "name": "wUSDKRateProvider",
-            "summary": "safe",
-            "review": "./wUSDKRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843": {
-            "name": "TruMaticRateProvider",
-            "summary": "safe",
-            "review": "./TruMaticRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843",
-                    "implementationReviewed": "0x6e8135b003F288aA4009D948e9646588861C5575"
-                },
-                {
-                    "entrypoint": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
-                    "implementationReviewed": "0x2a9fD373Ed3Ce392bb5ad8Ee146CFAB66c9fAEae"
-                },
-                {
-                    "entrypoint": "0xeA077b10A0eD33e4F68Edb2655C18FDA38F84712",
-                    "implementationReviewed": "0xf98864DA30a5bd657B13e70A57f5718aBf7BAB31"
-                },
-                {
-                    "entrypoint": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
-                    "implementationReviewed": "0xbA9Ac3C9983a3e967f0f387c75cCbD38Ad484963"
-                }
-            ]
-        },
-        "0xf518f2EbeA5df8Ca2B5E9C7996a2A25e8010014b": {
-            "name": "MevEthRateProvider",
-            "summary": "safe",
-            "review": "./MevEthRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee": {
-            "name": "WeETH",
-            "summary": "safe",
-            "review": "./WeETH.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
-                    "implementationReviewed": "0xe629ee84C1Bd9Ea9c677d2D5391919fCf5E7d5D9"
-                },
-                {
-                    "entrypoint": "0x308861A430be4cce5502d0A12724771Fc6DaF216",
-                    "implementationReviewed": "0x4D784Aa9eacc108ea5A326747870897f88d93860"
-                },
-                {
-                    "entrypoint": "0x35fA164735182de50811E8e2E824cFb9B6118ac2",
-                    "implementationReviewed": "0x1B47A665364bC15C28B05f449B53354d0CefF72f"
-                },
-                {
-                    "entrypoint": "0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000",
-                    "implementationReviewed": "0x047A7749AD683C2Fd8A27C7904Ca8dD128F15889"
-                },
-                {
-                    "entrypoint": "0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705",
-                    "implementationReviewed": "0x9D6fC3cBaaD0ef36b2B3a4b4b311C9dd267a4aeA"
-                },
-                {
-                    "entrypoint": "0x57AaF0004C716388B21795431CD7D5f9D3Bb6a41",
-                    "implementationReviewed": "0x698cB4508F13Cc12aAD36D2B64413C302B781d9A"
-                }
-            ]
-        },
-        "0x8023518b2192FB5384DAdc596765B3dD1cdFe471": {
-            "name": "PriceFeed",
-            "summary": "safe",
-            "review": "./osEthRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0x387dBc0fB00b26fb085aa658527D5BE98302c84C": {
-            "name": "BalancerRateProvider",
-            "summary": "safe",
-            "review": "ezETHRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
-                    "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
-                },
-                {
-                    "entrypoint": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
-                    "implementationReviewed": "0x1e756B7bCca7B26FB9D85344B3525F5559bbacb0"
-                },
-                {
-                    "entrypoint": "0x74a09653A083691711cF8215a6ab074BB4e99ef5",
-                    "implementationReviewed": "0x18Ac4D26ACD4c5C4FE98C9098D2E5e1e501A042a"
-                },
-                {
-                    "entrypoint": "0x4994EFc62101A9e3F885d872514c2dC7b3235849",
-                    "implementationReviewed": "0x09aA40B6e0e768a04d650302e1879DCED6b7666E"
-                },
-                {
-                    "entrypoint": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042",
-                    "implementationReviewed": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042"
-                },
-                {
-                    "entrypoint": "0xbAf5f3A05BD7Af6f3a0BBA207803bf77e2657c8F",
-                    "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
-                },
-                {
-                    "entrypoint": "0x0B1981a9Fcc24A445dE15141390d3E46DA0e425c",
-                    "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
-                }
-            ]
-        },
-        "0x746df66bc1Bb361b9E8E2a794C299c3427976e6C": {
-            "name": "RsETHRateProvider",
-            "summary": "safe",
-            "review": "rsETHRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x349A73444b1a310BAe67ef67973022020d70020d",
-                    "implementationReviewed": "0xf1bed40dbee8fc0f324fa06322f2bbd62d11c97d,"
-                },
-                {
-                    "entrypoint": "0x947Cb49334e6571ccBFEF1f1f1178d8469D65ec7",
-                    "implementationReviewed": "0x8d9cd771c51b7f6217e0000c1c735f05adbe6594"
-                },
-                {
-                    "entrypoint": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
-                    "implementationReviewed": "0x8e2fe2f55f295f3f141213789796fa79e709ef23"
-                },
-                {
-                    "entrypoint": "0x3D08ccb47ccCde84755924ED6B0642F9aB30dFd2",
-                    "implementationReviewed": "0x0379e85188bc416a1d43ab04b28f38b5c63f129e"
-                },
-                {
-                    "entrypoint": "0x8546A7C8C3C537914C3De24811070334568eF427",
-                    "implementationReviewed": "0xd7db9604ef925af96cda6b45026be64c691c7704"
-                }
-            ]
-        },
-        "0xad4bFaFAe75ECd3fED5cFad4E4E9847Cd47A1879": {
-            "name": "svETHRateProvider",
-            "summary": "safe",
-            "review": "sveth.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0",
-                    "implementationReviewed": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0"
-                }
-            ]
-        },
-        "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0": {
-            "name": "RswETH",
-            "summary": "safe",
-            "review": "./rswethRateProvider.md",
-            "warnings": [
-                ""
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
-                    "implementationReviewed": "0xcD284A617b4ED7697c2E455d95049c7Fc538785c"
-                },
-                {
-                    "entrypoint": "0xd5A73c748449a45CC7D9f21c7ed3aB9eB3D2e959",
-                    "implementationReviewed": "0xF00E70450EB294C6fe430c842A09796D73c28977"
-                },
-                {
-                    "entrypoint": "0x796592b2092F7E150C48643dA19Dd2F28be3333F",
-                    "implementationReviewed": "0x527d6db79bFf473B8DD722429bDB3B0C8b855D23"
-                }
-            ]
-        },
-        "0xD02011C6C8AEE310D0aA42AA98BFE9DCa547fCc0": {
-            "name": "ERC4626RateProvider",
-            "summary": "safe",
-            "review": "./sDOLARateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0x9cE2837d6d84bb521A5a3002a2132B9E9E9cc4C8": {
-            "name": "BalancerAMM",
-            "summary": "safe",
-            "review": "./sweepRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-                    "implementationReviewed": "0xf0604A1c725F8eeb14FF082F2275AfE0B67A32D5"
-                }
-            ]
-        },
-        "0x343281Bb5029C4b698fE736D800115ac64D5De39": {
-            "name": "InstETHRateProvider",
-            "summary": "safe",
-            "review": "./InstETHRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x814CC6B8fd2555845541FB843f37418b05977d8d",
-                    "implementationReviewed": "0xbBf7fc7036B60D1E88913bD583dC5E39957F9f17"
-                },
-                {
-                    "entrypoint": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
-                    "implementationReviewed": "0xBAa61A8d8BC52f5a9256612Fab498c542188A132"
-                }
-            ]
-        },
-        "0xC29783738A475112Cafe58433Dd9D19F3a406619": {
-            "name": "GenEthRateProvider",
-            "summary": "safe",
-            "review": "./genETHRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
-                    "implementationReviewed": "0x59114182500d834b8E41A397314C97EeE96Ee9bD"
-                },
-                {
-                    "entrypoint": "0x81b98D3a51d4aC35e0ae132b0CF6b50EA1Da2603",
-                    "implementationReviewed": "0xe99AD80f1367ef20e81Ad72134192358670F7bf9"
-                },
-                {
-                    "entrypoint": "0x122ee24Cb3Cc1b6B987800D3B54A68FC16910Dbf",
-                    "implementationReviewed": "0xB7A63a69cc0e635915e65379D2794f0b687D63EC"
-                }
-            ]
-        },
-        "0x72D07D7DcA67b8A406aD1Ec34ce969c90bFEE768": {
-            "name": "WstETHRateProvider",
-            "summary": "safe",
-            "review": "./wstethRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": []
-        }
+      "0x2c3b8c5e98A6e89AAAF21Deebf5FF9d08c4A9FF7": {
+        "asset": "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4",
+        "name": "BalancerRateProxy",
+        "summary": "safe",
+        "review": "./BalancerRateProxy_uniETH.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x4beFa2aA9c305238AA3E0b5D17eB20C045269E9d",
+            "implementationReviewed": "0x9Ba573D531b45521a4409f3D3e1bC0d7dfF7C757"
+          }
+        ]
+      },
+      "0xAAE054B9b822554dd1D9d1F48f892B4585D3bbf0": {
+        "asset": "0xA35b1B31Ce002FBF2058D22F30f95D405200A15b",
+        "name": "ETHxRateProvider",
+        "summary": "safe",
+        "review": "./ETHxRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xcf5EA1b38380f6aF39068375516Daf40Ed70D299",
+            "implementationReviewed": "0x9dceaeB1C035C1427E64E6c6fEC61F816e0d0FF5"
+          }
+        ]
+      },
+      "0xA6aeD7922366611953546014A3f9e93f058756a2": {
+        "asset": "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d",
+        "name": "QueenRateProvider",
+        "summary": "safe",
+        "review": "./QueenRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0x67560A970FFaB46D65cB520dD3C2fF4E684f29c2": {
+        "asset": "0xC4cafEFBc3dfeA629c589728d648CB6111DB3136",
+        "name": "TBYRateProvider",
+        "summary": "safe",
+        "review": "./TBYRateProvider.md",
+        "warnings": [],
+        "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
+        "upgradeableComponents": []
+      },
+      "0xDceC4350d189Ea7e1DD2C9BDa63cB0e0Ae34b81F": {
+        "asset": "0x8dc5BE35672D650bc8A176A4bafBfC33555D80AC",
+        "name": "TBYRateProvider",
+        "summary": "safe",
+        "review": "./TBYRateProvider.md",
+        "warnings": [],
+        "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
+        "upgradeableComponents": []
+      },
+      "0xc7177B6E18c1Abd725F5b75792e5F7A3bA5DBC2c": {
+        "asset": "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
+        "name": "SavingsDAIRateProvider",
+        "summary": "safe",
+        "review": "./SavingsDAIRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0xd8689E8740C23d73136744817347fd6aC464E842": {
+        "asset": "0xaF4ce7CD4F8891ecf1799878c3e9A35b8BE57E09",
+        "name": "wUSDKRateProvider",
+        "summary": "safe",
+        "review": "./wUSDKRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843": {
+        "asset": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
+        "name": "TruMaticRateProvider",
+        "summary": "safe",
+        "review": "./TruMaticRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843",
+            "implementationReviewed": "0x6e8135b003F288aA4009D948e9646588861C5575"
+          },
+          {
+            "entrypoint": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
+            "implementationReviewed": "0x2a9fD373Ed3Ce392bb5ad8Ee146CFAB66c9fAEae"
+          },
+          {
+            "entrypoint": "0xeA077b10A0eD33e4F68Edb2655C18FDA38F84712",
+            "implementationReviewed": "0xf98864DA30a5bd657B13e70A57f5718aBf7BAB31"
+          },
+          {
+            "entrypoint": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+            "implementationReviewed": "0xbA9Ac3C9983a3e967f0f387c75cCbD38Ad484963"
+          }
+        ]
+      },
+      "0xf518f2EbeA5df8Ca2B5E9C7996a2A25e8010014b": {
+        "asset": "0x24Ae2dA0f361AA4BE46b48EB19C91e02c5e4f27E",
+        "name": "MevEthRateProvider",
+        "summary": "safe",
+        "review": "./MevEthRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee": {
+        "asset": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
+        "name": "WeETH",
+        "summary": "safe",
+        "review": "./WeETH.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
+            "implementationReviewed": "0xe629ee84C1Bd9Ea9c677d2D5391919fCf5E7d5D9"
+          },
+          {
+            "entrypoint": "0x308861A430be4cce5502d0A12724771Fc6DaF216",
+            "implementationReviewed": "0x4D784Aa9eacc108ea5A326747870897f88d93860"
+          },
+          {
+            "entrypoint": "0x35fA164735182de50811E8e2E824cFb9B6118ac2",
+            "implementationReviewed": "0x1B47A665364bC15C28B05f449B53354d0CefF72f"
+          },
+          {
+            "entrypoint": "0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000",
+            "implementationReviewed": "0x047A7749AD683C2Fd8A27C7904Ca8dD128F15889"
+          },
+          {
+            "entrypoint": "0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705",
+            "implementationReviewed": "0x9D6fC3cBaaD0ef36b2B3a4b4b311C9dd267a4aeA"
+          },
+          {
+            "entrypoint": "0x57AaF0004C716388B21795431CD7D5f9D3Bb6a41",
+            "implementationReviewed": "0x698cB4508F13Cc12aAD36D2B64413C302B781d9A"
+          }
+        ]
+      },
+      "0x8023518b2192FB5384DAdc596765B3dD1cdFe471": {
+        "asset": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
+        "name": "PriceFeed",
+        "summary": "safe",
+        "review": "./osEthRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0x387dBc0fB00b26fb085aa658527D5BE98302c84C": {
+        "asset": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
+        "name": "BalancerRateProvider",
+        "summary": "safe",
+        "review": "ezETHRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
+            "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
+          },
+          {
+            "entrypoint": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
+            "implementationReviewed": "0x1e756B7bCca7B26FB9D85344B3525F5559bbacb0"
+          },
+          {
+            "entrypoint": "0x74a09653A083691711cF8215a6ab074BB4e99ef5",
+            "implementationReviewed": "0x18Ac4D26ACD4c5C4FE98C9098D2E5e1e501A042a"
+          },
+          {
+            "entrypoint": "0x4994EFc62101A9e3F885d872514c2dC7b3235849",
+            "implementationReviewed": "0x09aA40B6e0e768a04d650302e1879DCED6b7666E"
+          },
+          {
+            "entrypoint": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042",
+            "implementationReviewed": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042"
+          },
+          {
+            "entrypoint": "0xbAf5f3A05BD7Af6f3a0BBA207803bf77e2657c8F",
+            "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
+          },
+          {
+            "entrypoint": "0x0B1981a9Fcc24A445dE15141390d3E46DA0e425c",
+            "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
+          }
+        ]
+      },
+      "0x746df66bc1Bb361b9E8E2a794C299c3427976e6C": {
+        "asset": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
+        "name": "RsETHRateProvider",
+        "summary": "safe",
+        "review": "rsETHRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x349A73444b1a310BAe67ef67973022020d70020d",
+            "implementationReviewed": "0xf1bed40dbee8fc0f324fa06322f2bbd62d11c97d,"
+          },
+          {
+            "entrypoint": "0x947Cb49334e6571ccBFEF1f1f1178d8469D65ec7",
+            "implementationReviewed": "0x8d9cd771c51b7f6217e0000c1c735f05adbe6594"
+          },
+          {
+            "entrypoint": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
+            "implementationReviewed": "0x8e2fe2f55f295f3f141213789796fa79e709ef23"
+          },
+          {
+            "entrypoint": "0x3D08ccb47ccCde84755924ED6B0642F9aB30dFd2",
+            "implementationReviewed": "0x0379e85188bc416a1d43ab04b28f38b5c63f129e"
+          },
+          {
+            "entrypoint": "0x8546A7C8C3C537914C3De24811070334568eF427",
+            "implementationReviewed": "0xd7db9604ef925af96cda6b45026be64c691c7704"
+          }
+        ]
+      },
+      "0xad4bFaFAe75ECd3fED5cFad4E4E9847Cd47A1879": {
+        "asset": "0x6733F0283711F225A447e759D859a70b0c0Fd2bC",
+        "name": "svETHRateProvider",
+        "summary": "safe",
+        "review": "sveth.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0",
+            "implementationReviewed": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0"
+          }
+        ]
+      },
+      "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0": {
+        "asset": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
+        "name": "RswETH",
+        "summary": "safe",
+        "review": "./rswethRateProvider.md",
+        "warnings": [""],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
+            "implementationReviewed": "0xcD284A617b4ED7697c2E455d95049c7Fc538785c"
+          },
+          {
+            "entrypoint": "0xd5A73c748449a45CC7D9f21c7ed3aB9eB3D2e959",
+            "implementationReviewed": "0xF00E70450EB294C6fe430c842A09796D73c28977"
+          },
+          {
+            "entrypoint": "0x796592b2092F7E150C48643dA19Dd2F28be3333F",
+            "implementationReviewed": "0x527d6db79bFf473B8DD722429bDB3B0C8b855D23"
+          }
+        ]
+      },
+      "0xD02011C6C8AEE310D0aA42AA98BFE9DCa547fCc0": {
+        "asset": "0xb45ad160634c528Cc3D2926d9807104FA3157305",
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./sDOLARateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0x9cE2837d6d84bb521A5a3002a2132B9E9E9cc4C8": {
+        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+        "name": "BalancerAMM",
+        "summary": "safe",
+        "review": "./sweepRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+            "implementationReviewed": "0xf0604A1c725F8eeb14FF082F2275AfE0B67A32D5"
+          }
+        ]
+      },
+      "0x343281Bb5029C4b698fE736D800115ac64D5De39": {
+        "asset": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
+        "name": "InstETHRateProvider",
+        "summary": "safe",
+        "review": "./InstETHRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x814CC6B8fd2555845541FB843f37418b05977d8d",
+            "implementationReviewed": "0xbBf7fc7036B60D1E88913bD583dC5E39957F9f17"
+          },
+          {
+            "entrypoint": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
+            "implementationReviewed": "0xBAa61A8d8BC52f5a9256612Fab498c542188A132"
+          }
+        ]
+      },
+      "0xC29783738A475112Cafe58433Dd9D19F3a406619": {
+        "asset": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
+        "name": "GenEthRateProvider",
+        "summary": "safe",
+        "review": "./genETHRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
+            "implementationReviewed": "0x59114182500d834b8E41A397314C97EeE96Ee9bD"
+          },
+          {
+            "entrypoint": "0x81b98D3a51d4aC35e0ae132b0CF6b50EA1Da2603",
+            "implementationReviewed": "0xe99AD80f1367ef20e81Ad72134192358670F7bf9"
+          },
+          {
+            "entrypoint": "0x122ee24Cb3Cc1b6B987800D3B54A68FC16910Dbf",
+            "implementationReviewed": "0xB7A63a69cc0e635915e65379D2794f0b687D63EC"
+          }
+        ]
+      },
+      "0x72D07D7DcA67b8A406aD1Ec34ce969c90bFEE768": {
+        "asset": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+        "name": "WstETHRateProvider",
+        "summary": "safe",
+        "review": "./wstethRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": []
+      }
     },
     "gnosis": {
-        "0x89C80A4540A00b5270347E02e2E144c71da2EceD": {
-            "name": "ERC4626RateProvider",
-            "summary": "safe",
-            "review": "./SavingsDAIRateProviderGnosis.md",
-            "warnings": [
-                "donation",
-                "only18decimals"
-            ],
-            "factory": "",
-            "upgradeableComponents": []
-        },
-        "0xff315299C4d3FB984b67e31F028724b6a9aEb077": {
-            "name": "ERC4626RateProvider",
-            "summary": "safe",
-            "review": "./stAgEurRateProvider.md",
-            "warnings": [
-                "donation",
-                "only18decimals"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
-                    "implementationReviewed": "0x6C04c39B9E73aC91106D12F828e2E29Fd8ef1024"
-                },
-                {
-                    "entrypoint": "0x4b1E2c2762667331Bc91648052F646d1b0d35984",
-                    "implementationReviewed": "0x59153e939c5b4721543251ff3049Ea04c755373B"
-                }
-            ]
-        }
+      "0x89C80A4540A00b5270347E02e2E144c71da2EceD": {
+        "asset": "0xaf204776c7245bF4147c2612BF6e5972Ee483701",
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./SavingsDAIRateProviderGnosis.md",
+        "warnings": ["donation", "only18decimals"],
+        "factory": "",
+        "upgradeableComponents": []
+      },
+      "0xff315299C4d3FB984b67e31F028724b6a9aEb077": {
+        "asset": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./stAgEurRateProvider.md - now stEUR",
+        "warnings": ["donation", "only18decimals"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
+            "implementationReviewed": "0x6C04c39B9E73aC91106D12F828e2E29Fd8ef1024"
+          },
+          {
+            "entrypoint": "0x4b1E2c2762667331Bc91648052F646d1b0d35984",
+            "implementationReviewed": "0x59153e939c5b4721543251ff3049Ea04c755373B"
+          }
+        ]
+      }
     },
     "optimism": {
-        "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
-            "name": "WrappedUsdPlusRateProvider",
-            "summary": "safe",
-            "review": "./WrappedUsdPlusRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
-                    "implementationReviewed": "0x52A8F84672B9778632F98478B4DCfa2Efb7E3247"
-                },
-                {
-                    "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
-                    "implementationReviewed": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376"
-                },
-                {
-                    "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-                    "implementationReviewed": "0xcf02cf91b5ec8230d6bd26c48a8b762ce6081c0f"
-                },
-                {
-                    "entrypoint": "0xBf3FCee0E856c2aa89dc022f00D6D8159A80F011",
-                    "implementationReviewed": "0x98ae7F3fD47100b174014dCD143Eb43AD7acd79A"
-                }
-            ]
-        },
-        "0xBCEBb4dcdEc1c12bf7eB31bd26bc9C3b8F55C966": {
-            "name": "",
-            "summary": "safe",
-            "review": "./stERNRateProvider.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xFBD08A6869D3e4EC8A21895c1e269f4b980813f0",
-                    "implementationReviewed": "0xfA097bD1E57d720C2f884C3DFF0B5FCE23A2B09e"
-                },
-                {
-                    "entrypoint": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
-                    "implementationReviewed": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB"
-                }
-            ]
-        },
-        "0x33A48e4aA79A66fc4f7061f5D9E274528C213029": {
-            "name": "BalancerAMM",
-            "summary": "safe",
-            "review": "./sweepRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-                    "implementationReviewed": "0x8adEa764cabd2C61E51cEb6937Fd026fA39d8E64"
-                }
-            ]
-        }
+      "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
+        "asset": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
+        "name": "WrappedUsdPlusRateProvider",
+        "summary": "safe",
+        "review": "./WrappedUsdPlusRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
+            "implementationReviewed": "0x52A8F84672B9778632F98478B4DCfa2Efb7E3247"
+          },
+          {
+            "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
+            "implementationReviewed": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376"
+          },
+          {
+            "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+            "implementationReviewed": "0xcf02cf91b5ec8230d6bd26c48a8b762ce6081c0f"
+          },
+          {
+            "entrypoint": "0xBf3FCee0E856c2aa89dc022f00D6D8159A80F011",
+            "implementationReviewed": "0x98ae7F3fD47100b174014dCD143Eb43AD7acd79A"
+          }
+        ]
+      },
+      "0xBCEBb4dcdEc1c12bf7eB31bd26bc9C3b8F55C966": {
+        "asset": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
+        "name": "",
+        "summary": "safe",
+        "review": "./stERNRateProvider.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xFBD08A6869D3e4EC8A21895c1e269f4b980813f0",
+            "implementationReviewed": "0xfA097bD1E57d720C2f884C3DFF0B5FCE23A2B09e"
+          },
+          {
+            "entrypoint": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
+            "implementationReviewed": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB"
+          }
+        ]
+      },
+      "0x33A48e4aA79A66fc4f7061f5D9E274528C213029": {
+        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+        "name": "BalancerAMM",
+        "summary": "safe",
+        "review": "./sweepRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+            "implementationReviewed": "0x8adEa764cabd2C61E51cEb6937Fd026fA39d8E64"
+          }
+        ]
+      }
     },
     "polygon": {
-        "0x76D8B79Fb9afD4dA89913458C90B6C09676628E2": {
-            "name": "RateProvider",
-            "summary": "safe",
-            "review": "./RateProvider_wFRK.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x2cb7285733A30BB08303B917A7a519C88146C6Eb",
-                    "implementationReviewed": "0xEdb20e3cD8C7c149Ea57fe470fb9685c4b1B8703"
-                },
-                {
-                    "entrypoint": "0x4dBA794671B891D2Ee2E3E7eA9E993026219941C",
-                    "implementationReviewed": "0x7714fcFe0d9C4726F6C1E3B1275C2951B9B54F65"
-                },
-                {
-                    "entrypoint": "0x0aC2E3Cd1E9b2DA91972d2363e76B5A0cE514e73",
-                    "implementationReviewed": "0x41d4D26F70951a2134DC862ea6248fFBE2a516bb"
-                },
-                {
-                    "entrypoint": "0x173EB1d561CcEFd8e83a3741483a8Bd76dF827Ef",
-                    "implementationReviewed": "0x72e923047245D2B58D87f311a2b5b487620EE60A"
-                }
-            ]
-        }
+      "0x76D8B79Fb9afD4dA89913458C90B6C09676628E2": {
+        "asset": "0x01d1a890D40d890d59795aFCce22F5AdbB511A3a",
+        "name": "RateProvider",
+        "summary": "safe",
+        "review": "./RateProvider_wFRK.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x2cb7285733A30BB08303B917A7a519C88146C6Eb",
+            "implementationReviewed": "0xEdb20e3cD8C7c149Ea57fe470fb9685c4b1B8703"
+          },
+          {
+            "entrypoint": "0x4dBA794671B891D2Ee2E3E7eA9E993026219941C",
+            "implementationReviewed": "0x7714fcFe0d9C4726F6C1E3B1275C2951B9B54F65"
+          },
+          {
+            "entrypoint": "0x0aC2E3Cd1E9b2DA91972d2363e76B5A0cE514e73",
+            "implementationReviewed": "0x41d4D26F70951a2134DC862ea6248fFBE2a516bb"
+          },
+          {
+            "entrypoint": "0x173EB1d561CcEFd8e83a3741483a8Bd76dF827Ef",
+            "implementationReviewed": "0x72e923047245D2B58D87f311a2b5b487620EE60A"
+          }
+        ]
+      }
     },
     "zkevm": {
-        "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
-            "name": "AnkrETHRateProvider",
-            "summary": "safe",
-            "review": "./AnkrETHRateProvider.md",
-            "warnings": [],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
-                    "implementationReviewed": "0x8d98D8ec0D930078a083C7be54430D2093d3D4aB"
-                },
-                {
-                    "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
-                    "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
-                }
-            ]
-        },
-        "0x4186BFC76E2E237523CBC30FD220FE055156b41F": {
-            "name": "RSETHRateReceiver",
-            "summary": "safe",
-            "review": "./rsEthRateProviderPolygonZKEVM.md",
-            "warnings": [
-                "donation"
-            ],
-            "factory": "",
-            "upgradeableComponents": [
-                {
-                    "entrypoint": "0x4186BFC76E2E237523CBC30FD220FE055156b41F",
-                    "implementationReviewed": "0x4186BFC76E2E237523CBC30FD220FE055156b41F"
-                }
-            ]
-        }
+      "0xFC8d81A01deD207aD3DEB4FE91437CAe52deD0b5": {
+        "asset": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+        "name": "AnkrETHRateProvider",
+        "summary": "safe",
+        "review": "./AnkrETHRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x12D8CE035c5DE3Ce39B1fDD4C1d5a745EAbA3b8C",
+            "implementationReviewed": "0x8d98D8ec0D930078a083C7be54430D2093d3D4aB"
+          },
+          {
+            "entrypoint": "0xEf3C162450E1d08804493aA27BE60CDAa054050F",
+            "implementationReviewed": "0xd00b967296B6d8Ec266E4BA64594f892D03A4d0a"
+          }
+        ]
+      },
+      "0x4186BFC76E2E237523CBC30FD220FE055156b41F": {
+        "asset": "0x8C7D118B5c47a5BCBD47cc51789558B98dAD17c5",
+        "name": "RSETHRateReceiver",
+        "summary": "safe",
+        "review": "./rsEthRateProviderPolygonZKEVM.md",
+        "warnings": ["donation"],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x4186BFC76E2E237523CBC30FD220FE055156b41F",
+            "implementationReviewed": "0x4186BFC76E2E237523CBC30FD220FE055156b41F"
+          }
+        ]
+      }
     }
+  }
 }

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -131,6 +131,98 @@
             "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
           }
         ]
+      },
+      "0x87cD462A781c0ca843EAB131Bf368328848bB6fD": {
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./statATokenLMRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x7CFaDFD5645B50bE87d546f42699d863648251ad",
+            "implementationReviewed": "0x4c0633bf70fb2bb984a9eec5d9052bdea451c70a"
+          },
+          {
+            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+            "implementationReviewed": "0x03e8c5cd5e194659b16456bb43dd5d38886fe541"
+          }
+        ]
+      },
+      "0x48942B49B5bB6f3E1d43c204a3F40a4c5F696ef6": {
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./statATokenLMRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xb165a74407fE1e519d6bCbDeC1Ed3202B35a4140",
+            "implementationReviewed": "0x4c0633bf70fb2bb984a9eec5d9052bdea451c70a"
+          },
+          {
+            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+            "implementationReviewed": "0x03e8c5cd5e194659b16456bb43dd5d38886fe541"
+          }
+        ]
+      },
+      "0x3A236F67Fce401D87D7215695235e201966576E4": {
+        "name": "MergedAdapterWithoutRoundsSusdeRateProviderV1",
+        "summary": "safe",
+        "review": "./sUSDERateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x3A236F67Fce401D87D7215695235e201966576E4",
+            "implementationReviewed": "0x0e2d75D760b12ac1F2aE84CD2FF9fD13Cb632942"
+          }
+        ]
+      },
+      "0x8aa73EC870DC4a0af6b471937682a8FC3b8A21f8": {
+        "name": "StakePoolRate",
+        "summary": "safe",
+        "review": "./jitoSOLRateProvider.md",
+        "warnings": [],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0xa5f208e072434bC67592E4C49C1B991BA79BCA46",
+            "implementationReviewed": "0x621199f6beB2ba6fbD962E8A52A320EA4F6D4aA3"
+          }
+        ]
+      },
+      "0xd983d5560129475bFC210332422FAdCb4EcD09B0": {
+        "asset": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
+        "name": "cbETH Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Chainlink"],
+        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+      },
+      "0x2237a270E87F81A30a1980422185f806e4549346": {
+        "asset": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
+        "name": "sfrxETH Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Chainlink"],
+        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+      },
+      "0x320CFa1a78d37a13C5D1cA5aA51563fF6Bb0f686": {
+        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
+        "name": "sFRAX Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Chainlink"],
+        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
+      },
+      "0x155a25c8C3a9353d47BCDBc3650E19d1aEa13E54": {
+        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
+        "name": "sFRAX Rate Provider Duplicate",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Chainlink"],
+        "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd"
       }
     },
     "avalanche": {
@@ -193,453 +285,786 @@
             "implementationReviewed": "0x8A7d9967A31fe557041519c131B355176734d907"
           }
         ]
+      },
+      "0x5f8147f9e4fB550C5be815C8a20013171eEFB46D": {
+        "asset": "0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE",
+        "name": "sAVAX Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
       }
     },
-    "base": {
-      "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
-        "asset": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
-        "name": "WrappedUsdPlusRateProvider",
-        "summary": "safe",
-        "review": "./WrappedUsdPlusRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
-            "implementationReviewed": "0xE3434045a3bE5376e8d3Cf841981835996561f80"
-          },
-          {
-            "entrypoint": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
-            "implementationReviewed": "0x441Df98011aD427C5692418999ba2150e6d84277"
-          },
-          {
-            "entrypoint": "0x7cb1B38591021309C64f451859d79312d8Ca2789",
-            "implementationReviewed": "0x083f016e9928a3eaa3aca0ff9f4e4ded5db3b4b7"
-          },
-          {
-            "entrypoint": "0x8ab9012D1BfF1b62c2ad82AE0106593371e6b247",
-            "implementationReviewed": "0x292F13d4BfD6f6aE0Bf8Be981bcC44eC4850e5E9"
-          }
-        ]
-      }
+    "0xD70C8AaC058E6daFe3446F78091325F9E29bcee4": {
+      "asset": "0xc3344870d52688874b06d844E0C36cc39FC727F6",
+      "name": "ankrAVAX Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    }
+  },
+  "base": {
+    "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
+      "asset": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
+      "name": "WrappedUsdPlusRateProvider",
+      "summary": "safe",
+      "review": "./WrappedUsdPlusRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
+          "implementationReviewed": "0xE3434045a3bE5376e8d3Cf841981835996561f80"
+        },
+        {
+          "entrypoint": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376",
+          "implementationReviewed": "0x441Df98011aD427C5692418999ba2150e6d84277"
+        },
+        {
+          "entrypoint": "0x7cb1B38591021309C64f451859d79312d8Ca2789",
+          "implementationReviewed": "0x083f016e9928a3eaa3aca0ff9f4e4ded5db3b4b7"
+        },
+        {
+          "entrypoint": "0x8ab9012D1BfF1b62c2ad82AE0106593371e6b247",
+          "implementationReviewed": "0x292F13d4BfD6f6aE0Bf8Be981bcC44eC4850e5E9"
+        }
+      ]
     },
-    "ethereum": {
-      "0x2c3b8c5e98A6e89AAAF21Deebf5FF9d08c4A9FF7": {
-        "asset": "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4",
-        "name": "BalancerRateProxy",
-        "summary": "safe",
-        "review": "./BalancerRateProxy_uniETH.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x4beFa2aA9c305238AA3E0b5D17eB20C045269E9d",
-            "implementationReviewed": "0x9Ba573D531b45521a4409f3D3e1bC0d7dfF7C757"
-          }
-        ]
-      },
-      "0xAAE054B9b822554dd1D9d1F48f892B4585D3bbf0": {
-        "asset": "0xA35b1B31Ce002FBF2058D22F30f95D405200A15b",
-        "name": "ETHxRateProvider",
-        "summary": "safe",
-        "review": "./ETHxRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xcf5EA1b38380f6aF39068375516Daf40Ed70D299",
-            "implementationReviewed": "0x9dceaeB1C035C1427E64E6c6fEC61F816e0d0FF5"
-          }
-        ]
-      },
-      "0xA6aeD7922366611953546014A3f9e93f058756a2": {
-        "asset": "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d",
-        "name": "QueenRateProvider",
-        "summary": "safe",
-        "review": "./QueenRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0x67560A970FFaB46D65cB520dD3C2fF4E684f29c2": {
-        "asset": "0xC4cafEFBc3dfeA629c589728d648CB6111DB3136",
-        "name": "TBYRateProvider",
-        "summary": "safe",
-        "review": "./TBYRateProvider.md",
-        "warnings": [],
-        "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
-        "upgradeableComponents": []
-      },
-      "0xDceC4350d189Ea7e1DD2C9BDa63cB0e0Ae34b81F": {
-        "asset": "0x8dc5BE35672D650bc8A176A4bafBfC33555D80AC",
-        "name": "TBYRateProvider",
-        "summary": "safe",
-        "review": "./TBYRateProvider.md",
-        "warnings": [],
-        "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
-        "upgradeableComponents": []
-      },
-      "0xc7177B6E18c1Abd725F5b75792e5F7A3bA5DBC2c": {
-        "asset": "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
-        "name": "SavingsDAIRateProvider",
-        "summary": "safe",
-        "review": "./SavingsDAIRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0xd8689E8740C23d73136744817347fd6aC464E842": {
-        "asset": "0xaF4ce7CD4F8891ecf1799878c3e9A35b8BE57E09",
-        "name": "wUSDKRateProvider",
-        "summary": "safe",
-        "review": "./wUSDKRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843": {
-        "asset": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
-        "name": "TruMaticRateProvider",
-        "summary": "safe",
-        "review": "./TruMaticRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843",
-            "implementationReviewed": "0x6e8135b003F288aA4009D948e9646588861C5575"
-          },
-          {
-            "entrypoint": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
-            "implementationReviewed": "0x2a9fD373Ed3Ce392bb5ad8Ee146CFAB66c9fAEae"
-          },
-          {
-            "entrypoint": "0xeA077b10A0eD33e4F68Edb2655C18FDA38F84712",
-            "implementationReviewed": "0xf98864DA30a5bd657B13e70A57f5718aBf7BAB31"
-          },
-          {
-            "entrypoint": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
-            "implementationReviewed": "0xbA9Ac3C9983a3e967f0f387c75cCbD38Ad484963"
-          }
-        ]
-      },
-      "0xf518f2EbeA5df8Ca2B5E9C7996a2A25e8010014b": {
-        "asset": "0x24Ae2dA0f361AA4BE46b48EB19C91e02c5e4f27E",
-        "name": "MevEthRateProvider",
-        "summary": "safe",
-        "review": "./MevEthRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee": {
-        "asset": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
-        "name": "WeETH",
-        "summary": "safe",
-        "review": "./WeETH.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
-            "implementationReviewed": "0xe629ee84C1Bd9Ea9c677d2D5391919fCf5E7d5D9"
-          },
-          {
-            "entrypoint": "0x308861A430be4cce5502d0A12724771Fc6DaF216",
-            "implementationReviewed": "0x4D784Aa9eacc108ea5A326747870897f88d93860"
-          },
-          {
-            "entrypoint": "0x35fA164735182de50811E8e2E824cFb9B6118ac2",
-            "implementationReviewed": "0x1B47A665364bC15C28B05f449B53354d0CefF72f"
-          },
-          {
-            "entrypoint": "0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000",
-            "implementationReviewed": "0x047A7749AD683C2Fd8A27C7904Ca8dD128F15889"
-          },
-          {
-            "entrypoint": "0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705",
-            "implementationReviewed": "0x9D6fC3cBaaD0ef36b2B3a4b4b311C9dd267a4aeA"
-          },
-          {
-            "entrypoint": "0x57AaF0004C716388B21795431CD7D5f9D3Bb6a41",
-            "implementationReviewed": "0x698cB4508F13Cc12aAD36D2B64413C302B781d9A"
-          }
-        ]
-      },
-      "0x8023518b2192FB5384DAdc596765B3dD1cdFe471": {
-        "asset": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
-        "name": "PriceFeed",
-        "summary": "safe",
-        "review": "./osEthRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0x387dBc0fB00b26fb085aa658527D5BE98302c84C": {
-        "asset": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
-        "name": "BalancerRateProvider",
-        "summary": "safe",
-        "review": "ezETHRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
-            "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
-          },
-          {
-            "entrypoint": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
-            "implementationReviewed": "0x1e756B7bCca7B26FB9D85344B3525F5559bbacb0"
-          },
-          {
-            "entrypoint": "0x74a09653A083691711cF8215a6ab074BB4e99ef5",
-            "implementationReviewed": "0x18Ac4D26ACD4c5C4FE98C9098D2E5e1e501A042a"
-          },
-          {
-            "entrypoint": "0x4994EFc62101A9e3F885d872514c2dC7b3235849",
-            "implementationReviewed": "0x09aA40B6e0e768a04d650302e1879DCED6b7666E"
-          },
-          {
-            "entrypoint": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042",
-            "implementationReviewed": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042"
-          },
-          {
-            "entrypoint": "0xbAf5f3A05BD7Af6f3a0BBA207803bf77e2657c8F",
-            "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
-          },
-          {
-            "entrypoint": "0x0B1981a9Fcc24A445dE15141390d3E46DA0e425c",
-            "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
-          }
-        ]
-      },
-      "0x746df66bc1Bb361b9E8E2a794C299c3427976e6C": {
-        "asset": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
-        "name": "RsETHRateProvider",
-        "summary": "safe",
-        "review": "rsETHRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x349A73444b1a310BAe67ef67973022020d70020d",
-            "implementationReviewed": "0xf1bed40dbee8fc0f324fa06322f2bbd62d11c97d,"
-          },
-          {
-            "entrypoint": "0x947Cb49334e6571ccBFEF1f1f1178d8469D65ec7",
-            "implementationReviewed": "0x8d9cd771c51b7f6217e0000c1c735f05adbe6594"
-          },
-          {
-            "entrypoint": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
-            "implementationReviewed": "0x8e2fe2f55f295f3f141213789796fa79e709ef23"
-          },
-          {
-            "entrypoint": "0x3D08ccb47ccCde84755924ED6B0642F9aB30dFd2",
-            "implementationReviewed": "0x0379e85188bc416a1d43ab04b28f38b5c63f129e"
-          },
-          {
-            "entrypoint": "0x8546A7C8C3C537914C3De24811070334568eF427",
-            "implementationReviewed": "0xd7db9604ef925af96cda6b45026be64c691c7704"
-          }
-        ]
-      },
-      "0xad4bFaFAe75ECd3fED5cFad4E4E9847Cd47A1879": {
-        "asset": "0x6733F0283711F225A447e759D859a70b0c0Fd2bC",
-        "name": "svETHRateProvider",
-        "summary": "safe",
-        "review": "sveth.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0",
-            "implementationReviewed": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0"
-          }
-        ]
-      },
-      "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0": {
-        "asset": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
-        "name": "RswETH",
-        "summary": "safe",
-        "review": "./rswethRateProvider.md",
-        "warnings": [""],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
-            "implementationReviewed": "0xcD284A617b4ED7697c2E455d95049c7Fc538785c"
-          },
-          {
-            "entrypoint": "0xd5A73c748449a45CC7D9f21c7ed3aB9eB3D2e959",
-            "implementationReviewed": "0xF00E70450EB294C6fe430c842A09796D73c28977"
-          },
-          {
-            "entrypoint": "0x796592b2092F7E150C48643dA19Dd2F28be3333F",
-            "implementationReviewed": "0x527d6db79bFf473B8DD722429bDB3B0C8b855D23"
-          }
-        ]
-      },
-      "0xD02011C6C8AEE310D0aA42AA98BFE9DCa547fCc0": {
-        "asset": "0xb45ad160634c528Cc3D2926d9807104FA3157305",
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./sDOLARateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0x9cE2837d6d84bb521A5a3002a2132B9E9E9cc4C8": {
-        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-        "name": "BalancerAMM",
-        "summary": "safe",
-        "review": "./sweepRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-            "implementationReviewed": "0xf0604A1c725F8eeb14FF082F2275AfE0B67A32D5"
-          }
-        ]
-      },
-      "0x343281Bb5029C4b698fE736D800115ac64D5De39": {
-        "asset": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
-        "name": "InstETHRateProvider",
-        "summary": "safe",
-        "review": "./InstETHRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x814CC6B8fd2555845541FB843f37418b05977d8d",
-            "implementationReviewed": "0xbBf7fc7036B60D1E88913bD583dC5E39957F9f17"
-          },
-          {
-            "entrypoint": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
-            "implementationReviewed": "0xBAa61A8d8BC52f5a9256612Fab498c542188A132"
-          }
-        ]
-      },
-      "0xC29783738A475112Cafe58433Dd9D19F3a406619": {
-        "asset": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
-        "name": "GenEthRateProvider",
-        "summary": "safe",
-        "review": "./genETHRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
-            "implementationReviewed": "0x59114182500d834b8E41A397314C97EeE96Ee9bD"
-          },
-          {
-            "entrypoint": "0x81b98D3a51d4aC35e0ae132b0CF6b50EA1Da2603",
-            "implementationReviewed": "0xe99AD80f1367ef20e81Ad72134192358670F7bf9"
-          },
-          {
-            "entrypoint": "0x122ee24Cb3Cc1b6B987800D3B54A68FC16910Dbf",
-            "implementationReviewed": "0xB7A63a69cc0e635915e65379D2794f0b687D63EC"
-          }
-        ]
-      },
-      "0x72D07D7DcA67b8A406aD1Ec34ce969c90bFEE768": {
-        "asset": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-        "name": "WstETHRateProvider",
-        "summary": "safe",
-        "review": "./wstethRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": []
-      }
+    "0xeC0C14Ea7fF20F104496d960FDEBF5a0a0cC14D0": {
+      "name": "DSRBalancerRateProviderAdapter",
+      "summary": "safe",
+      "review": "./DSRRateProviderBase.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
     },
-    "gnosis": {
-      "0x89C80A4540A00b5270347E02e2E144c71da2EceD": {
-        "asset": "0xaf204776c7245bF4147c2612BF6e5972Ee483701",
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./SavingsDAIRateProviderGnosis.md",
-        "warnings": ["donation", "only18decimals"],
-        "factory": "",
-        "upgradeableComponents": []
-      },
-      "0xff315299C4d3FB984b67e31F028724b6a9aEb077": {
-        "asset": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
-        "name": "ERC4626RateProvider",
-        "summary": "safe",
-        "review": "./stAgEurRateProvider.md - now stEUR",
-        "warnings": ["donation", "only18decimals"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
-            "implementationReviewed": "0x6C04c39B9E73aC91106D12F828e2E29Fd8ef1024"
-          },
-          {
-            "entrypoint": "0x4b1E2c2762667331Bc91648052F646d1b0d35984",
-            "implementationReviewed": "0x59153e939c5b4721543251ff3049Ea04c755373B"
-          }
-        ]
-      }
+    "0x3786a6CAAB433f5dfE56503207DF31DF87C5b5C1": {
+      "asset": "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
+      "name": "cbETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B"
     },
-    "optimism": {
-      "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
-        "asset": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
-        "name": "WrappedUsdPlusRateProvider",
-        "summary": "safe",
-        "review": "./WrappedUsdPlusRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
-            "implementationReviewed": "0x52A8F84672B9778632F98478B4DCfa2Efb7E3247"
-          },
-          {
-            "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
-            "implementationReviewed": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376"
-          },
-          {
-            "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
-            "implementationReviewed": "0xcf02cf91b5ec8230d6bd26c48a8b762ce6081c0f"
-          },
-          {
-            "entrypoint": "0xBf3FCee0E856c2aa89dc022f00D6D8159A80F011",
-            "implementationReviewed": "0x98ae7F3fD47100b174014dCD143Eb43AD7acd79A"
-          }
-        ]
-      },
-      "0xBCEBb4dcdEc1c12bf7eB31bd26bc9C3b8F55C966": {
-        "asset": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
-        "name": "",
-        "summary": "safe",
-        "review": "./stERNRateProvider.md",
-        "warnings": ["donation"],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xFBD08A6869D3e4EC8A21895c1e269f4b980813f0",
-            "implementationReviewed": "0xfA097bD1E57d720C2f884C3DFF0B5FCE23A2B09e"
-          },
-          {
-            "entrypoint": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
-            "implementationReviewed": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB"
-          }
-        ]
-      },
-      "0x33A48e4aA79A66fc4f7061f5D9E274528C213029": {
-        "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-        "name": "BalancerAMM",
-        "summary": "safe",
-        "review": "./sweepRateProvider.md",
-        "warnings": [],
-        "factory": "",
-        "upgradeableComponents": [
-          {
-            "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
-            "implementationReviewed": "0x8adEa764cabd2C61E51cEb6937Fd026fA39d8E64"
-          }
-        ]
-      }
+    "0x1Fe586225989Dd88365C2D859670AA0A4379d7e4": {
+      "asset": "0x1f55a02A049033E3419a8E2975cF3F572F4e6E9A",
+      "name": "sfrxETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B"
+    },
+    "0x5a7A419C59eAAdec8Dc00bc93ac95612e6e154Cf": {
+      "asset": "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A",
+      "name": "weETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B"
+    },
+    "0x039f7205C2cBa4535C2575123Ac3D657263892c4": {
+      "asset": "0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c",
+      "name": "rETH RocketPool Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0xe1b1e024f4Bc01Bdde23e891E081b76a1A914ddd": {
+      "asset": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
+      "name": "wUSD+ Overnight Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    }
+  },
+  "ethereum": {
+    "0x2c3b8c5e98A6e89AAAF21Deebf5FF9d08c4A9FF7": {
+      "asset": "0xF1376bceF0f78459C0Ed0ba5ddce976F1ddF51F4",
+      "name": "BalancerRateProxy",
+      "summary": "safe",
+      "review": "./BalancerRateProxy_uniETH.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x4beFa2aA9c305238AA3E0b5D17eB20C045269E9d",
+          "implementationReviewed": "0x9Ba573D531b45521a4409f3D3e1bC0d7dfF7C757"
+        }
+      ]
+    },
+    "0xAAE054B9b822554dd1D9d1F48f892B4585D3bbf0": {
+      "asset": "0xA35b1B31Ce002FBF2058D22F30f95D405200A15b",
+      "name": "ETHxRateProvider",
+      "summary": "safe",
+      "review": "./ETHxRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xcf5EA1b38380f6aF39068375516Daf40Ed70D299",
+          "implementationReviewed": "0x9dceaeB1C035C1427E64E6c6fEC61F816e0d0FF5"
+        }
+      ]
+    },
+    "0xA6aeD7922366611953546014A3f9e93f058756a2": {
+      "asset": "0x93ef1Ea305D11A9b2a3EbB9bB4FCc34695292E7d",
+      "name": "QueenRateProvider",
+      "summary": "safe",
+      "review": "./QueenRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x67560A970FFaB46D65cB520dD3C2fF4E684f29c2": {
+      "asset": "0xC4cafEFBc3dfeA629c589728d648CB6111DB3136",
+      "name": "TBYRateProvider",
+      "summary": "safe",
+      "review": "./TBYRateProvider.md",
+      "warnings": [],
+      "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
+      "upgradeableComponents": []
+    },
+    "0xDceC4350d189Ea7e1DD2C9BDa63cB0e0Ae34b81F": {
+      "asset": "0x8dc5BE35672D650bc8A176A4bafBfC33555D80AC",
+      "name": "TBYRateProvider",
+      "summary": "safe",
+      "review": "./TBYRateProvider.md",
+      "warnings": [],
+      "factory": "0x97390050B63eb56C0e39bB0D8d364333Eb3AFD12",
+      "upgradeableComponents": []
+    },
+    "0xc7177B6E18c1Abd725F5b75792e5F7A3bA5DBC2c": {
+      "asset": "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
+      "name": "SavingsDAIRateProvider",
+      "summary": "safe",
+      "review": "./SavingsDAIRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0xd8689E8740C23d73136744817347fd6aC464E842": {
+      "asset": "0xaF4ce7CD4F8891ecf1799878c3e9A35b8BE57E09",
+      "name": "wUSDKRateProvider",
+      "summary": "safe",
+      "review": "./wUSDKRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843": {
+      "asset": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
+      "name": "TruMaticRateProvider",
+      "summary": "safe",
+      "review": "./TruMaticRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x4b697C8c3220FcBdd02DFFa46db5a896ae7a0843",
+          "implementationReviewed": "0x6e8135b003F288aA4009D948e9646588861C5575"
+        },
+        {
+          "entrypoint": "0xA43A7c62D56dF036C187E1966c03E2799d8987ed",
+          "implementationReviewed": "0x2a9fD373Ed3Ce392bb5ad8Ee146CFAB66c9fAEae"
+        },
+        {
+          "entrypoint": "0xeA077b10A0eD33e4F68Edb2655C18FDA38F84712",
+          "implementationReviewed": "0xf98864DA30a5bd657B13e70A57f5718aBf7BAB31"
+        },
+        {
+          "entrypoint": "0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908",
+          "implementationReviewed": "0xbA9Ac3C9983a3e967f0f387c75cCbD38Ad484963"
+        }
+      ]
+    },
+    "0xf518f2EbeA5df8Ca2B5E9C7996a2A25e8010014b": {
+      "asset": "0x24Ae2dA0f361AA4BE46b48EB19C91e02c5e4f27E",
+      "name": "MevEthRateProvider",
+      "summary": "safe",
+      "review": "./MevEthRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee": {
+      "asset": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
+      "name": "WeETH",
+      "summary": "safe",
+      "review": "./WeETH.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee",
+          "implementationReviewed": "0xe629ee84C1Bd9Ea9c677d2D5391919fCf5E7d5D9"
+        },
+        {
+          "entrypoint": "0x308861A430be4cce5502d0A12724771Fc6DaF216",
+          "implementationReviewed": "0x4D784Aa9eacc108ea5A326747870897f88d93860"
+        },
+        {
+          "entrypoint": "0x35fA164735182de50811E8e2E824cFb9B6118ac2",
+          "implementationReviewed": "0x1B47A665364bC15C28B05f449B53354d0CefF72f"
+        },
+        {
+          "entrypoint": "0x3d320286E014C3e1ce99Af6d6B00f0C1D63E3000",
+          "implementationReviewed": "0x047A7749AD683C2Fd8A27C7904Ca8dD128F15889"
+        },
+        {
+          "entrypoint": "0x0EF8fa4760Db8f5Cd4d993f3e3416f30f942D705",
+          "implementationReviewed": "0x9D6fC3cBaaD0ef36b2B3a4b4b311C9dd267a4aeA"
+        },
+        {
+          "entrypoint": "0x57AaF0004C716388B21795431CD7D5f9D3Bb6a41",
+          "implementationReviewed": "0x698cB4508F13Cc12aAD36D2B64413C302B781d9A"
+        }
+      ]
+    },
+    "0x8023518b2192FB5384DAdc596765B3dD1cdFe471": {
+      "asset": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38",
+      "name": "PriceFeed",
+      "summary": "safe",
+      "review": "./osEthRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x387dBc0fB00b26fb085aa658527D5BE98302c84C": {
+      "asset": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
+      "name": "BalancerRateProvider",
+      "summary": "safe",
+      "review": "ezETHRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x387dBc0fB00b26fb085aa658527D5BE98302c84C",
+          "implementationReviewed": "0x9284cEFf248315377e782df0666EE9832E119508"
+        },
+        {
+          "entrypoint": "0xbf5495Efe5DB9ce00f80364C8B423567e58d2110",
+          "implementationReviewed": "0x1e756B7bCca7B26FB9D85344B3525F5559bbacb0"
+        },
+        {
+          "entrypoint": "0x74a09653A083691711cF8215a6ab074BB4e99ef5",
+          "implementationReviewed": "0x18Ac4D26ACD4c5C4FE98C9098D2E5e1e501A042a"
+        },
+        {
+          "entrypoint": "0x4994EFc62101A9e3F885d872514c2dC7b3235849",
+          "implementationReviewed": "0x09aA40B6e0e768a04d650302e1879DCED6b7666E"
+        },
+        {
+          "entrypoint": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042",
+          "implementationReviewed": "0x5a12796f7e7EBbbc8a402667d266d2e65A814042"
+        },
+        {
+          "entrypoint": "0xbAf5f3A05BD7Af6f3a0BBA207803bf77e2657c8F",
+          "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
+        },
+        {
+          "entrypoint": "0x0B1981a9Fcc24A445dE15141390d3E46DA0e425c",
+          "implementationReviewed": "0xceEa4f26924F2CF55f59A560d6F323241728019a"
+        }
+      ]
+    },
+    "0x746df66bc1Bb361b9E8E2a794C299c3427976e6C": {
+      "asset": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
+      "name": "RsETHRateProvider",
+      "summary": "safe",
+      "review": "rsETHRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x349A73444b1a310BAe67ef67973022020d70020d",
+          "implementationReviewed": "0xf1bed40dbee8fc0f324fa06322f2bbd62d11c97d,"
+        },
+        {
+          "entrypoint": "0x947Cb49334e6571ccBFEF1f1f1178d8469D65ec7",
+          "implementationReviewed": "0x8d9cd771c51b7f6217e0000c1c735f05adbe6594"
+        },
+        {
+          "entrypoint": "0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7",
+          "implementationReviewed": "0x8e2fe2f55f295f3f141213789796fa79e709ef23"
+        },
+        {
+          "entrypoint": "0x3D08ccb47ccCde84755924ED6B0642F9aB30dFd2",
+          "implementationReviewed": "0x0379e85188bc416a1d43ab04b28f38b5c63f129e"
+        },
+        {
+          "entrypoint": "0x8546A7C8C3C537914C3De24811070334568eF427",
+          "implementationReviewed": "0xd7db9604ef925af96cda6b45026be64c691c7704"
+        }
+      ]
+    },
+    "0xad4bFaFAe75ECd3fED5cFad4E4E9847Cd47A1879": {
+      "asset": "0x6733F0283711F225A447e759D859a70b0c0Fd2bC",
+      "name": "svETHRateProvider",
+      "summary": "safe",
+      "review": "sveth.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0",
+          "implementationReviewed": "0x38D64ce1Bdf1A9f24E0Ec469C9cAde61236fB4a0"
+        }
+      ]
+    },
+    "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0": {
+      "asset": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
+      "name": "RswETH",
+      "summary": "safe",
+      "review": "./rswethRateProvider.md",
+      "warnings": [""],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0",
+          "implementationReviewed": "0xcD284A617b4ED7697c2E455d95049c7Fc538785c"
+        },
+        {
+          "entrypoint": "0xd5A73c748449a45CC7D9f21c7ed3aB9eB3D2e959",
+          "implementationReviewed": "0xF00E70450EB294C6fe430c842A09796D73c28977"
+        },
+        {
+          "entrypoint": "0x796592b2092F7E150C48643dA19Dd2F28be3333F",
+          "implementationReviewed": "0x527d6db79bFf473B8DD722429bDB3B0C8b855D23"
+        }
+      ]
+    },
+    "0xD02011C6C8AEE310D0aA42AA98BFE9DCa547fCc0": {
+      "asset": "0xb45ad160634c528Cc3D2926d9807104FA3157305",
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./sDOLARateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x9cE2837d6d84bb521A5a3002a2132B9E9E9cc4C8": {
+      "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+      "name": "BalancerAMM",
+      "summary": "safe",
+      "review": "./sweepRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+          "implementationReviewed": "0xf0604A1c725F8eeb14FF082F2275AfE0B67A32D5"
+        }
+      ]
+    },
+    "0x343281Bb5029C4b698fE736D800115ac64D5De39": {
+      "asset": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
+      "name": "InstETHRateProvider",
+      "summary": "safe",
+      "review": "./InstETHRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x814CC6B8fd2555845541FB843f37418b05977d8d",
+          "implementationReviewed": "0xbBf7fc7036B60D1E88913bD583dC5E39957F9f17"
+        },
+        {
+          "entrypoint": "0x7FA768E035F956c41d6aeaa3Bd857e7E5141CAd5",
+          "implementationReviewed": "0xBAa61A8d8BC52f5a9256612Fab498c542188A132"
+        }
+      ]
+    },
+    "0xC29783738A475112Cafe58433Dd9D19F3a406619": {
+      "asset": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
+      "name": "GenEthRateProvider",
+      "summary": "safe",
+      "review": "./genETHRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xf073bAC22DAb7FaF4a3Dd6c6189a70D54110525C",
+          "implementationReviewed": "0x59114182500d834b8E41A397314C97EeE96Ee9bD"
+        },
+        {
+          "entrypoint": "0x81b98D3a51d4aC35e0ae132b0CF6b50EA1Da2603",
+          "implementationReviewed": "0xe99AD80f1367ef20e81Ad72134192358670F7bf9"
+        },
+        {
+          "entrypoint": "0x122ee24Cb3Cc1b6B987800D3B54A68FC16910Dbf",
+          "implementationReviewed": "0xB7A63a69cc0e635915e65379D2794f0b687D63EC"
+        }
+      ]
+    },
+    "0x72D07D7DcA67b8A406aD1Ec34ce969c90bFEE768": {
+      "asset": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "name": "WstETHRateProvider",
+      "summary": "safe",
+      "review": "./wstethRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x71f80e2CfAFA5EC2F0bF12f71FA7Ea57c3D0c7Af": {
+      "name": "",
+      "summary": "safe",
+      "review": "./PufEthRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x71f80e2CfAFA5EC2F0bF12f71FA7Ea57c3D0c7Af",
+          "implementationReviewed": "0x1025aAa9ceB206303984Af4cc831B8A792c363d0"
+        },
+        {
+          "entrypoint": "0xD9A442856C234a39a81a089C06451EBAa4306a72",
+          "implementationReviewed": "0x39Ca0a6438B6050ea2aC909Ba65920c7451305C1"
+        }
+      ]
+    },
+    "0xB3351000db2A9a3638d6bbf1c229BEFeb98377DB": {
+      "name": "MswETHRateProvider",
+      "summary": "safe",
+      "review": "./MagpieMswETHRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x32bd822d615A3658A68b6fDD30c2fcb2C996D678",
+          "implementationReviewed": "0x19513d54df2e0e8432f6053f08e10907a2165d4e"
+        },
+        {
+          "entrypoint": "0x20b70E4A1883b81429533FeD944d7957121c7CAB",
+          "implementationReviewed": "0x90790a124c8a598651beb56243e92679bd012761"
+        },
+        {
+          "entrypoint": "0x9daA893D4Dfb96F46eA879f08ca46f39DaC07767",
+          "implementationReviewed": "0xfd2145b374cd9f6cc3bcde92b08e0018adc743d0"
+        }
+      ]
+    },
+    "0xCC701e2D472dFa2857Bf9AE24c263DAa39fD2C61": {
+      "name": "./MagpieMstETHRateProvider.md",
+      "summary": "safe",
+      "review": "./MagpieMstETHRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x49446A0874197839D15395B908328a74ccc96Bc0",
+          "implementationReviewed": "0x50e0D2241f45DBfE071B6A05b798B028a39BF0bd"
+        },
+        {
+          "entrypoint": "0x20b70E4A1883b81429533FeD944d7957121c7CAB",
+          "implementationReviewed": "0x90790a124c8a598651beb56243e92679bd012761"
+        },
+        {
+          "entrypoint": "0x9daA893D4Dfb96F46eA879f08ca46f39DaC07767",
+          "implementationReviewed": "0xfd2145b374cd9f6cc3bcde92b08e0018adc743d0"
+        }
+      ]
+    },
+    "0x3A244e6B3cfed21593a5E5B347B593C0B48C7dA1": {
+      "name": "EthenaBalancerRateProvider",
+      "summary": "safe",
+      "review": "./sUSDERateProviderMainnet.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x033E20068Db853Fa6C077F38faa4670423FC55fF": {
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./sFRAXRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x1a8F81c256aee9C640e14bB0453ce247ea0DFE6F": {
+      "asset": "0xae78736Cd615f374D3085123A210448E74Fc6393",
+      "name": "RocketBalancerRETHRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x302013E7936a39c358d07A3Df55dc94EC417E3a1": {
+      "asset": "0xac3E018457B222d93114458476f3E3416Abbe38F",
+      "name": "sfrxETH ERC4626RateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x00F8e64a8651E3479A0B20F46b1D462Fe29D6aBc": {
+      "asset": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
+      "name": "AnkrETHRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x7311E4BB8a72e7B300c5B8BDE4de6CdaA822a5b1": {
+      "asset": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+      "name": "CbEthRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x3D40f9dd83bd404fA4047c15da494E58C3c1f1ac": {
+      "asset": "0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593",
+      "name": "Stafi RETHRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x3556F710c165090AAE9f98Eb62F5b04ADeF7Eaea": {
+      "asset": "0x198d7387Fa97A73F05b8578CdEFf8F2A1f34Cd1F",
+      "name": "jAuraRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0xf951E335afb289353dc249e82926178EaC7DEd78": {
+      "asset": "0xf951E335afb289353dc249e82926178EaC7DEd78",
+      "name": "swETH Rate Provider TransparentUpgradeableProxy",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0xdE76434352633349f119bcE523d092743fEF20E9": {
+      "asset": "0xa2E3356610840701BDf5611a53974510Ae27E2e1",
+      "name": "wBETH BinanceBeaconEthRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x12589A727aeFAc3fbE5025F890f1CB97c269BEc2": {
+      "asset": "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F",
+      "name": "Bitfrost vETHRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x5F0A29e479744DcA0D3d912f87F1a6E3237A55D3": {
+      "asset": "0x0Ae38f7E10A43B5b2fB064B42a2f4514cbA909ef",
+      "name": "unshETHRateProvider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    }
+  },
+  "gnosis": {
+    "0x89C80A4540A00b5270347E02e2E144c71da2EceD": {
+      "asset": "0xaf204776c7245bF4147c2612BF6e5972Ee483701",
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./SavingsDAIRateProviderGnosis.md",
+      "warnings": ["donation", "only18decimals"],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0xff315299C4d3FB984b67e31F028724b6a9aEb077": {
+      "asset": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./stAgEurRateProvider.md - now stEUR",
+      "warnings": ["donation", "only18decimals"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
+          "implementationReviewed": "0x6C04c39B9E73aC91106D12F828e2E29Fd8ef1024"
+        },
+        {
+          "entrypoint": "0x4b1E2c2762667331Bc91648052F646d1b0d35984",
+          "implementationReviewed": "0x59153e939c5b4721543251ff3049Ea04c755373B"
+        }
+      ]
+    },
+    "0x09f9611FE9d24c6A518f656E925e3628A2ECDE3b": {
+      "asset": "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
+      "name": "wstETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0xE7511f6e5C593007eA8A7F52af4B066333765e03"
+    },
+    "0xE7511f6e5C593007eA8A7F52af4B066333765e03": {
+      "asset": "0xcB444e90D8198415266c6a2724b7900fb12FC56E",
+      "name": "EURe Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0xE7511f6e5C593007eA8A7F52af4B066333765e03"
+    }
+  },
+  "optimism": {
+    "0xe561451322a5efC51E6f8ffa558C7482c892Bc1A": {
+      "asset": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
+      "name": "WrappedUsdPlusRateProvider",
+      "summary": "safe",
+      "review": "./WrappedUsdPlusRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xA348700745D249c3b49D2c2AcAC9A5AE8155F826",
+          "implementationReviewed": "0x52A8F84672B9778632F98478B4DCfa2Efb7E3247"
+        },
+        {
+          "entrypoint": "0x73cb180bf0521828d8849bc8CF2B920918e23032",
+          "implementationReviewed": "0xB79DD08EA68A908A97220C76d19A6aA9cBDE4376"
+        },
+        {
+          "entrypoint": "0xe80772Eaf6e2E18B651F160Bc9158b2A5caFCA65",
+          "implementationReviewed": "0xcf02cf91b5ec8230d6bd26c48a8b762ce6081c0f"
+        },
+        {
+          "entrypoint": "0xBf3FCee0E856c2aa89dc022f00D6D8159A80F011",
+          "implementationReviewed": "0x98ae7F3fD47100b174014dCD143Eb43AD7acd79A"
+        }
+      ]
+    },
+    "0xBCEBb4dcdEc1c12bf7eB31bd26bc9C3b8F55C966": {
+      "asset": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
+      "name": "",
+      "summary": "safe",
+      "review": "./stERNRateProvider.md",
+      "warnings": ["donation"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xFBD08A6869D3e4EC8A21895c1e269f4b980813f0",
+          "implementationReviewed": "0xfA097bD1E57d720C2f884C3DFF0B5FCE23A2B09e"
+        },
+        {
+          "entrypoint": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB",
+          "implementationReviewed": "0x3eE6107d9C93955acBb3f39871D32B02F82B78AB"
+        }
+      ]
+    },
+    "0x33A48e4aA79A66fc4f7061f5D9E274528C213029": {
+      "asset": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+      "name": "BalancerAMM",
+      "summary": "safe",
+      "review": "./sweepRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xB88a5Ac00917a02d82c7cd6CEBd73E2852d43574",
+          "implementationReviewed": "0x8adEa764cabd2C61E51cEb6937Fd026fA39d8E64"
+        }
+      ]
+    },
+    "0xdFa8d2b3c146b8a10B5d63CA0306AEa84B602cfb": {
+      "name": "",
+      "summary": "safe",
+      "review": "./statATokenLMRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x4DD03dfD36548C840B563745e3FBeC320F37BA7e",
+          "implementationReviewed": "0xD792a3779D3C80bAEe8CF3304D6aEAc74bC432BE"
+        },
+        {
+          "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "implementationReviewed": "0x03e8C5Cd5E194659b16456bb43Dd5D38886FE541"
+        }
+      ]
+    },
+    "0x3f921Ebabab0703BC06d1828D09a245e8390c263": {
+      "name": "",
+      "summary": "safe",
+      "review": "./statATokenLMRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x035c93db04E5aAea54E6cd0261C492a3e0638b37",
+          "implementationReviewed": "0xD792a3779D3C80bAEe8CF3304D6aEAc74bC432BE"
+        },
+        {
+          "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+          "implementationReviewed": "0x03e8C5Cd5E194659b16456bb43Dd5D38886FE541"
+        }
+      ]
+    },
+    "0x15ACEE5F73b36762Ab1a6b7C98787b8148447898": {
+      "name": "DSRBalancerRateProviderAdapter",
+      "summary": "safe",
+      "review": "./DSRRateProviderOp.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x9aa3cd420f830E049e2b223D0b07D8c809C94d15": {
+      "asset": "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
+      "name": "wstETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
+    },
+    "0xf752dd899F87a91370C1C8ac1488Aef6be687505": {
+      "asset": "0x484c2D6e3cDd945a8B2DF735e079178C1036578c",
+      "name": "sfrxETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
+    },
+    "0x7E13b8b95d887c2326C25e71815F33Ea10A2674e": {
+      "asset": "0x2Dd1B4D4548aCCeA497050619965f91f78b3b532",
+      "name": "sFRAX Rate Provider 2",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
+    },
+    "0xDe3B7eC86B67B05D312ac8FD935B6F59836F2c41": {
+      "asset": "0x2Dd1B4D4548aCCeA497050619965f91f78b3b532",
+      "name": "sFRAX Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
+    },
+    "0x7eA8B4e2CaBA854C3dD6bf9c5ebABa143BE7Fe9E": {
+      "asset": "TBD",
+      "name": "weETH Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Chainlink"],
+      "factory": "0x83E443EF4f9963C77bd860f94500075556668cb8"
+    },
+    "0x658843BB859B7b85cEAb5cF77167e3F0a78dFE7f": {
+      "asset": "0x9Bcef72be871e61ED4fBbc7630889beE758eb81D",
+      "name": "rETH RocketPool Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
+    },
+    "0x97b323fc033323B66159402bcDb9D7B9DC604235": {
+      "asset": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
+      "name": "ankrETH Staking Rate Provider",
+      "summary": "safe",
+      "review": "",
+      "warnings": ["Legacy"],
+      "factory": ""
     },
     "polygon": {
       "0x76D8B79Fb9afD4dA89913458C90B6C09676628E2": {
@@ -667,6 +1092,88 @@
             "implementationReviewed": "0x72e923047245D2B58D87f311a2b5b487620EE60A"
           }
         ]
+      },
+      "0x7d10050F608c8EFFf118eDd1416D82a0EF2d7531": {
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./statATokenLMRateProvider.md",
+        "warnings": [""],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x2dCa80061632f3F87c9cA28364d1d0c30cD79a19",
+            "implementationReviewed": "0x6a7192c55e9298874e49675a63d5ebb11ed99a66"
+          },
+          {
+            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+            "implementationReviewed": "0x1ed647b250e5b6d71dc7b25806f44c33f5658f71"
+          }
+        ]
+      },
+      "0x9977a61a6aa950044d4dcD8aA0cAb76F84ea5aCd": {
+        "name": "ERC4626RateProvider",
+        "summary": "safe",
+        "review": "./statATokenLMRateProvider.md",
+        "warnings": [""],
+        "factory": "",
+        "upgradeableComponents": [
+          {
+            "entrypoint": "0x87A1fdc4C726c459f597282be639a045062c0E46",
+            "implementationReviewed": "0x6a7192c55e9298874e49675a63d5ebb11ed99a66"
+          },
+          {
+            "entrypoint": "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
+            "implementationReviewed": "0x1ed647b250e5b6d71dc7b25806f44c33f5658f71"
+          }
+        ]
+      },
+      "0x8c1944E305c590FaDAf0aDe4f737f5f95a4971B6": {
+        "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+        "name": "wstETH / ETH Rate Provider",
+        "summary": "unsafe",
+        "review": "Do not use, wrong pricing pair",
+        "warnings": ["Chainlink"],
+        "factory": "0xa3b370092aeb56770B23315252aB5E16DAcBF62B"
+      },
+      "0x693A9Aca2f7b699BBd3d55d980Ac8a5D7a66868B": {
+        "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
+        "name": "wstETH-stETH Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Chainlink"],
+        "factory": "0xa3b370092aeb56770B23315252aB5E16DAcBF62B"
+      },
+      "0xeE652bbF72689AA59F0B8F981c9c90e2A8Af8d8f": {
+        "asset": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
+        "name": "MaticX Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
+      },
+      "0xdEd6C522d803E35f65318a9a4d7333a22d582199": {
+        "asset": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
+        "name": "stMATIC Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
+      },
+      "0x87393BE8ac323F2E63520A6184e5A8A9CC9fC051": {
+        "asset": "0xFcBB00dF1d663eeE58123946A30AB2138bF9eb2A",
+        "name": "csMATIC Clay Stack Tunnel Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
+      },
+      "0x737b6ea575AD54e0c4F45c7A36Ad8c0e730aAD74": {
+        "asset": "0xAF0D9D65fC54de245cdA37af3d18cbEc860A4D4b",
+        "name": "wUSDR Rate Provider",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
       }
     },
     "zkevm": {
@@ -701,174 +1208,23 @@
             "implementationReviewed": "0x4186BFC76E2E237523CBC30FD220FE055156b41F"
           }
         ]
+      },
+      "0x60b39BEC6AF8206d1E6E8DFC63ceA214A506D6c3": {
+        "asset": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
+        "name": "rETH Rate Receiver",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
+      },
+      "0x00346D2Fd4B2Dc3468fA38B857409BC99f832ef8": {
+        "asset": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
+        "name": "wstETH Rate Receiver",
+        "summary": "safe",
+        "review": "",
+        "warnings": ["Legacy"],
+        "factory": ""
       }
     }
-  },
-  "chainlink": {
-    "arbitrum": {
-      "0xd983d5560129475bFC210332422FAdCb4EcD09B0": {
-        "asset": "0x1DEBd73E752bEaF79865Fd6446b0c970EaE7732f",
-        "name": "cbETH Rate Provider"
-      },
-      "0x2237a270E87F81A30a1980422185f806e4549346": {
-        "asset": "0x95aB45875cFFdba1E5f451B950bC2E42c0053f39",
-        "name": "sfrxETH Rate Provider"
-      },
-      "0x320CFa1a78d37a13C5D1cA5aA51563fF6Bb0f686": {
-        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
-        "name": "sFRAX Rate Provider"
-      },
-      "0x155a25c8C3a9353d47BCDBc3650E19d1aEa13E54": {
-        "asset": "0xe3b3FE7bcA19cA77Ad877A5Bebab186bEcfAD906",
-        "name": "sFRAX Rate Provider Duplicate"
-      }
-    },
-      "avalanche": {},
-      "base": {
-        "0x3786a6CAAB433f5dfE56503207DF31DF87C5b5C1": {
-          "asset": "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
-          "name": "cbETH Rate Provider"
-        }
-      },
-      "ethereum": {},
-      "gnosis": {
-        "0x09f9611FE9d24c6A518f656E925e3628A2ECDE3b": {
-          "asset": "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
-          "name": "wstETH Rate Provider"
-        },
-        "0xE7511f6e5C593007eA8A7F52af4B066333765e03": {
-          "asset": "0xcB444e90D8198415266c6a2724b7900fb12FC56E",
-          "name": "EURe Rate Provider"
-        }
-      },
-      "optimism": {
-        "0x9aa3cd420f830E049e2b223D0b07D8c809C94d15": {
-          "asset": "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb",
-          "name": "wstETH Rate Provider"
-        },
-        "0xf752dd899F87a91370C1C8ac1488Aef6be687505": {
-          "asset": "0x484c2D6e3cDd945a8B2DF735e079178C1036578c",
-          "name": "sfrxETH Rate Provider"
-        },
-        "0xDe3B7eC86B67B05D312ac8FD935B6F59836F2c41": {
-          "asset": "0x2Dd1B4D4548aCCeA497050619965f91f78b3b532",
-          "name": "sFRAX Rate Provider"
-        }
-      }, 
-      "polygon": {
-        "0x8c1944E305c590FaDAf0aDe4f737f5f95a4971B6": {
-          "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
-          "name": "wstETH Rate Provider"
-        },
-        "0x693A9Aca2f7b699BBd3d55d980Ac8a5D7a66868B": {
-          "asset": "0x03b54A6e9a984069379fae1a4fC4dBAE93B3bCCD",
-          "name": "wstETH Rate Provider Duplicate"
-        }
-      },
-      "zkevm": {}
-  },
-  "legacy": {
-    "arbitrum": {},
-      "avalanche": {
-        "0x5f8147f9e4fB550C5be815C8a20013171eEFB46D": {
-          "asset": "0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE",
-          "name": "sAVAX Rate Provider"
-        },
-        "0xD70C8AaC058E6daFe3446F78091325F9E29bcee4": {
-          "asset": "0xc3344870d52688874b06d844E0C36cc39FC727F6",
-          "name": "ankrAVAX Rate Provider"
-        }
-      },
-      "base": {
-        "0x039f7205C2cBa4535C2575123Ac3D657263892c4": {
-          "asset": "0xB6fe221Fe9EeF5aBa221c348bA20A1Bf5e73624c",
-          "name": "rETH RocketPool Rate Provider"
-        },
-        "0xe1b1e024f4Bc01Bdde23e891E081b76a1A914ddd": {
-          "asset": "0xd95ca61CE9aAF2143E81Ef5462C0c2325172E028",
-          "name": "wUSD+ Overnight Rate Provider"
-        }
-      },
-      "ethereum": {
-        "0x1a8F81c256aee9C640e14bB0453ce247ea0DFE6F": {
-          "asset": "0xae78736Cd615f374D3085123A210448E74Fc6393",
-          "name": "RocketBalancerRETHRateProvider"
-        },
-        "0x302013E7936a39c358d07A3Df55dc94EC417E3a1": {
-          "asset": "0xac3E018457B222d93114458476f3E3416Abbe38F",
-          "name": "sfrxETH ERC4626RateProvider"
-        },
-        "0x00F8e64a8651E3479A0B20F46b1D462Fe29D6aBc": {
-          "asset": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb",
-          "name": "AnkrETHRateProvider"
-        },
-        "0x7311E4BB8a72e7B300c5B8BDE4de6CdaA822a5b1": {
-          "asset": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
-          "name": "CbEthRateProvider"
-        },
-        "0x3D40f9dd83bd404fA4047c15da494E58C3c1f1ac": {
-          "asset": "0x9559Aaa82d9649C7A7b220E7c461d2E74c9a3593",
-          "name": "Stafi RETHRateProvider"
-        },
-        "0x3556F710c165090AAE9f98Eb62F5b04ADeF7Eaea": {
-          "asset": "0x198d7387Fa97A73F05b8578CdEFf8F2A1f34Cd1F",
-          "name": "jAuraRateProvider"
-        },
-        "0xf951E335afb289353dc249e82926178EaC7DEd78": {
-          "asset": "0xf951E335afb289353dc249e82926178EaC7DEd78",
-          "name": "swETH Rate Provider TransparentUpgradeableProxy"
-        },
-        "0xdE76434352633349f119bcE523d092743fEF20E9": {
-          "asset": "0xa2E3356610840701BDf5611a53974510Ae27E2e1",
-          "name": "wBETH BinanceBeaconEthRateProvider"
-        },
-        "0x12589A727aeFAc3fbE5025F890f1CB97c269BEc2": {
-          "asset": "0x4Bc3263Eb5bb2Ef7Ad9aB6FB68be80E43b43801F",
-          "name": "Bitfrost vETHRateProvider"
-        },
-        "0x5F0A29e479744DcA0D3d912f87F1a6E3237A55D3": {
-          "asset": "0x0Ae38f7E10A43B5b2fB064B42a2f4514cbA909ef",
-          "name": "unshETHRateProvider"
-        }
-      },
-      "gnosis": {},
-      "optimism": {
-        "0x658843BB859B7b85cEAb5cF77167e3F0a78dFE7f": {
-          "asset": "0x9Bcef72be871e61ED4fBbc7630889beE758eb81D",
-          "name": "rETH RocketPool Rate Provider"
-        },
-        "0x97b323fc033323B66159402bcDb9D7B9DC604235": {
-          "asset": "0xe05A08226c49b636ACf99c40Da8DC6aF83CE5bB3",
-          "name": "ankrETH Staking Rate Provider"
-        }
-      },
-      "polygon": {
-        "0xeE652bbF72689AA59F0B8F981c9c90e2A8Af8d8f": {
-          "asset": "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6",
-          "name": "MaticX Rate Provider"
-        },
-        "0xdEd6C522d803E35f65318a9a4d7333a22d582199": {
-          "asset": "0x3A58a54C066FdC0f2D55FC9C89F0415C92eBf3C4",
-          "name": "stMATIC Rate Provider"
-        },
-        "0x87393BE8ac323F2E63520A6184e5A8A9CC9fC051": {
-          "asset": "0xFcBB00dF1d663eeE58123946A30AB2138bF9eb2A",
-          "name": "csMATIC Clay Stack Tunnel Rate Provider"
-        },
-        "0x737b6ea575AD54e0c4F45c7A36Ad8c0e730aAD74": {
-          "asset": "0xAF0D9D65fC54de245cdA37af3d18cbEc860A4D4b",
-          "name": "wUSDR Rate Provider"
-        }
-      },
-      "zkevm": { 
-        "0x60b39BEC6AF8206d1E6E8DFC63ceA214A506D6c3": {
-          "asset": "0xb23C20EFcE6e24Acca0Cef9B7B7aA196b84EC942",
-          "name": "rETH Rate Receiver"
-        },
-        "0x00346D2Fd4B2Dc3468fA38B857409BC99f832ef8": {
-          "asset": "0x5D8cfF95D7A57c0BF50B30b43c7CC0D52825D4a9",
-          "name": "wstETH Rate Receiver"
-        }
-      }
   }
 }


### PR DESCRIPTION
Posting this for @Zen-Maxi who can provide more details in comments. 

Complete list of current rate providers and their status in the ecosystem. Chainlink are separate but can likely be merged into the review section; this is a first pass. Legacy are unreviewed rate providers which are grandfathered in prior to our teams implementing reviews for rate contracts. Possible formatting clarifications are related to token -> rate provider address readability for ergonomic ease of use when querying. This will serve as a center of truth for future pool creations,****