### PR TITLE
ETHx-Arbitrum-Chainlink

### DIFF
--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -230,6 +230,15 @@
       "warnings": ["chainlink"],
       "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
       "upgradeableComponents": []
+    },
+    "0x8581953084FfdDBB82fC63f30f11bDb0E7300284": {
+      "asset": "0xED65C5085a18Fa160Af0313E60dcc7905E944Dc7",
+      "name": "ETHx Rate Provider",
+      "summary": "safe",
+      "review": "./ChainLinkRateProvider.md",
+      "warnings": ["chainlink"],
+      "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "upgradeableComponents": []
     }
   },
   "avalanche": {


### PR DESCRIPTION
Chainlink rate provider for ETHx on Arbitrum.

Pool: https://app.balancer.fi/#/arbitrum/pool/0x7b54c44fbe6db6d97fd22b8756f89c0af16202cc00000000000000000000053c

Token: https://arbiscan.io/address/0xed65c5085a18fa160af0313e60dcc7905e944dc7#code

Rate contract: https://arbiscan.io/address/0x8581953084ffddbb82fc63f30f11bdb0e7300284