### PR TITLE
GYD-Constant-Rate-Providers-Sept-2024

### DIFF
--- a/rate-providers/GYDConstantRateProvider.md
+++ b/rate-providers/GYDConstantRateProvider.md
@@ -5,6 +5,8 @@
 - Checked by: @danielmkm
 - Deployed at:
     - [arbitrum:0x3a216B01db971Bf28D171C9dA44Cc8C89867697F](https://arbiscan.io/address/0x3a216B01db971Bf28D171C9dA44Cc8C89867697F#code)
+    - [arbitrum:0x72F6Da3b4bd0Ab7028F52339Ee3B1f94fffe2dD0](https://arbiscan.io/address/0x72F6Da3b4bd0Ab7028F52339Ee3B1f94fffe2dD0#code) 
+    - [ethereum:0xD43F5a722e8e7355D790adda4642f392Dfb820a1](https://etherscan.io/address/0xD43F5a722e8e7355D790adda4642f392Dfb820a1#code)
 - Audit report(s):
     - [Gyro audits](https://docs.gyro.finance/gyroscope-protocol/audit-reports)
 

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -425,6 +425,15 @@
       "warnings": [],
       "factory": "",
       "upgradeableComponents": []
+    },
+    "0x72F6Da3b4bd0Ab7028F52339Ee3B1f94fffe2dD0": {
+      "asset": "0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+      "name": "ConstantRateProvider",
+      "summary": "safe",
+      "review": "./GYDConstantRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "avalanche": {
@@ -1399,6 +1408,15 @@
           "implementationReviewed": "0xd7097af27b14e204564c057c636022fae346fe60"
         }
       ]
+    },
+    "0xD43F5a722e8e7355D790adda4642f392Dfb820a1": {
+      "asset": "0xe07f9d810a48ab5c3c914ba3ca53af14e4491e8a",
+      "name": "ConstantRateProvider",
+      "summary": "safe",
+      "review": "./GYDConstantRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "fantom": {


### PR DESCRIPTION
Adding GYD constant rate providers on mainnet: https://etherscan.io/address/0xD43F5a722e8e7355D790adda4642f392Dfb820a1 and Arbitrum:
https://arbiscan.io/address/0x72F6Da3b4bd0Ab7028F52339Ee3B1f94fffe2dD0

At the request of issue #150