### PR TITLE
USDCConstantRateProvider

### DIFF
--- a/rate-providers/USDCConstantRateProvider.md
+++ b/rate-providers/USDCConstantRateProvider.md
@@ -11,7 +11,7 @@
     - [Gyro audits](https://docs.gyro.finance/gyroscope-protocol/audit-reports)
 
 ## Context
-This rate provider reports a constant rate which upscales the gyd price to a specific area of the ellipsis pricing function.
+This rate provider reports a constant rate which upscales the usdc price to a specific area of the ellipsis pricing function.
 > reason for the constant rate provider is to scale the prices that the pool does its math at to the part of the ellipse that is near 1:1 (as opposed to 2500:1 for ETH pricing). Reason there is because this region is better tested (although in principle, the rounding analysis should apply to a much wider range of parameters and pool prices -- but feels slightly safer to use the scaling)
 
 ## Review Checklist: Bare Minimum Compatibility

--- a/rate-providers/USDCConstantRateProvider.md
+++ b/rate-providers/USDCConstantRateProvider.md
@@ -1,0 +1,48 @@
+# Rate Provider: `ConstantRateProvider`
+
+## Details
+- Reviewed by: @Zen-Maxi
+- Checked by: @mkflow27
+- Deployed at:
+    - [base:0x5E10C2a55fB6E4C14c50C7f6B82bb28A813a4748](https://basescan.org/address/0x5E10C2a55fB6E4C14c50C7f6B82bb28A813a4748)
+    - [base:0x3e89cc86307aF44A77EB29d0c4163d515D348313](https://basescan.org/address/0x3e89cc86307aF44A77EB29d0c4163d515D348313) 
+    - [base:0x3fA516CEB5d068b60FDC0c68a3B793Fc43B88f15](https://basescan.org/address/0x3fA516CEB5d068b60FDC0c68a3B793Fc43B88f15)
+- Audit report(s):
+    - [Gyro audits](https://docs.gyro.finance/gyroscope-protocol/audit-reports)
+
+## Context
+This rate provider reports a constant rate which upscales the gyd price to a specific area of the ellipsis pricing function.
+> reason for the constant rate provider is to scale the prices that the pool does its math at to the part of the ellipse that is near 1:1 (as opposed to 2500:1 for ETH pricing). Reason there is because this region is better tested (although in principle, the rounding analysis should apply to a much wider range of parameters and pool prices -- but feels slightly safer to use the scaling)
+
+## Review Checklist: Bare Minimum Compatibility
+Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
+
+- [x] Implements the [`IRateProvider`](https://github.com/balancer/balancer-v2-monorepo/blob/bc3b3fee6e13e01d2efe610ed8118fdb74dfc1f2/pkg/interfaces/contracts/pool-utils/IRateProvider.sol) interface.
+- [x] `getRate` returns an 18-decimal fixed point number (i.e., 1 == 1e18) regardless of underlying token decimals.
+
+## Review Checklist: Common Findings
+Each of the items below represents a common red flag found in Rate Provider contracts.
+
+If none of these is checked, then this might be a pretty great Rate Provider! If any of these is checked, we must thoroughly elaborate on the conditions that lead to the potential issue. Decision points are not binary; a Rate Provider can be safe despite these boxes being checked. A check simply indicates that thorough vetting is required in a specific area, and this vetting should be used to inform a holistic analysis of the Rate Provider.
+
+### Administrative Privileges
+- [ ] The Rate Provider is upgradeable (e.g., via a proxy architecture or an `onlyOwner` function that updates the price source address). 
+
+- [ ] Some other portion of the price pipeline is upgradeable (e.g., the token itself, an oracle, or some piece of a larger system that tracks the price).
+
+### Oracles
+- [ ] Price data is provided by an off-chain source (e.g., a Chainlink oracle, a multisig, or a network of nodes).
+
+- [ ] Price data is expected to be volatile (e.g., because it represents an open market price instead of a (mostly) monotonically increasing price).
+
+### Common Manipulation Vectors
+- [ ] The Rate Provider is susceptible to donation attacks.
+
+
+## Additional Findings
+To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
+
+## Conclusion
+**Summary judgment: SAFE**
+
+The required `getRate` value for this particular case scales the balances to the required pricing point on the gyro pricing curve. For more information see also the [gauge proposal](https://forum.balancer.fi/t/bip-731-enable-several-e-clp-gauges-base/6148). Note: This rateProvider should not be used for other pools to provide rate data for USDC or similar stablecoins. 

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -650,6 +650,33 @@
       "warnings": ["legacy"],
       "factory": "",
       "upgradeableComponents": []
+    },
+    "0x5E10C2a55fB6E4C14c50C7f6B82bb28A813a4748": {
+      "asset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "name": "ConstantRateProvider",
+      "summary": "safe",
+      "review": "./USDCConstantRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x3e89cc86307aF44A77EB29d0c4163d515D348313": {
+      "asset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "name": "ConstantRateProvider",
+      "summary": "safe",
+      "review": "./USDCConstantRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
+    },
+    "0x3fA516CEB5d068b60FDC0c68a3B793Fc43B88f15": {
+      "asset": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "name": "ConstantRateProvider",
+      "summary": "safe",
+      "review": "./USDCConstantRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "ethereum": {

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -677,6 +677,15 @@
       "warnings": [],
       "factory": "",
       "upgradeableComponents": []
+    },
+    "0x3b3dd5f913443bb5E70389F29c83F7DCA460CAe1": {
+      "asset": "0xc1cba3fcea344f92d9239c08c0568f6f2f0ee452",
+      "name": "wstETH Rate Provider",
+      "summary": "safe",
+      "review": "./ChainLinkRateProvider.md",
+      "warnings": ["chainlink"],
+      "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B",
+      "upgradeableComponents": []
     }
   },
   "ethereum": {


### PR DESCRIPTION
Adds necessary rate providers to repo for Gyroscope proposal: https://forum.balancer.fi/t/bip-731-enable-several-e-clp-gauges-base/6148

This includes 3 constant rate providers which the format has been reviewed before for GYD, in this case for USDC. Also adding the chainlink rate provider deployed for wstETH on Base.