### PR TITLE
Fix asset addresses for Aave testnet rate providers

### DIFF
--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -2347,7 +2347,7 @@
   },
   "sepolia": {
     "0xB1B171A07463654cc1fE3df4eC05f754E41f0A65": {
-      "asset": "0xaA8E23Fb1079EA71e0a56F48a2aA51851D8433D0",
+      "asset": "0x978206fAe13faF5a8d293FB614326B237684B750",
       "name": "waUSDT Rate Provider",
       "summary": "safe",
       "review": "./StatATokenTestnetRateProvider.md",
@@ -2356,7 +2356,7 @@
       "upgradeableComponents": []
     },
     "0x22db61f3a8d81d3d427a157fdae8c7eb5b5fd373": {
-      "asset": "0xFF34B3d4Aee8ddCd6F9AFFFB6Fe49bD371b8a357",
+      "asset": "0xDE46e43F46ff74A23a65EBb0580cbe3dFE684a17",
       "name": "waDAI Rate Provider",
       "summary": "safe",
       "review": "./StatATokenTestnetRateProvider.md",
@@ -2365,7 +2365,7 @@
       "upgradeableComponents": []
     },
     "0x34101091673238545De8a846621823D9993c3085": {
-      "asset": "0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8",
+      "asset": "0x8A88124522dbBF1E56352ba3DE1d9F78C143751e",
       "name": "waUSDC Rate Provider",
       "summary": "safe",
       "review": "./StatATokenTestnetRateProvider.md",


### PR DESCRIPTION
For the rate provider registry, I accidentally put the underlying token addresses instead of the yield bearing, which I suspect is why API not returning the data I need