### PR TITLE
feat: add tokenized vaults to erc4626 registry

### DIFF
--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -2,7 +2,7 @@
 
 ## Details
 - Reviewed by: @mkflow27
-- Checked by: @\<GitHub handle of secondary reviewer\>
+- Checked by: @danielmkm
 - Deployed at:
     - [gnosis:0x773cda0cade2a3d86e6d4e30699d40bb95174ff2](https://gnosisscan.io/address/0x773cda0cade2a3d86e6d4e30699d40bb95174ff2#code)
     - [gnosis:0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644](https://gnosisscan.io/address/0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644)
@@ -11,7 +11,7 @@
     - [StatATokenV2 audits](https://github.com/aave-dao/aave-v3-origin/blob/067d29eb75115179501edc4316d125d9773f7928/audits/11-09-2024_Certora_StataTokenV2.pdf)
 
 ## Context
-A 4626 Vault which wrapps aTokens in order to translate the rebasing nature of yield accrual into a non-rebasing value accrual.
+A 4626 Vault which wraps aTokens in order to translate the rebasing nature of yield accrual into a non-rebasing value accrual.
 
 ## Review Checklist: Bare Minimum Compatibility
 Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.

--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -16,7 +16,7 @@ A 4626 Vault which wrapps aTokens in order to translate the rebasing nature of y
 ## Review Checklist: Bare Minimum Compatibility
 Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
 
-- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults.
+- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults, which can be found [here](https://github.com/balancer/balancer-v3-monorepo/pull/1171).
 - [x] The required Vault implements the required operational ERC4626 Interface
 
 ## Review Checklist: Common Findings
@@ -54,4 +54,4 @@ To save time, we do not bother pointing out low-severity/informational issues or
 ## Conclusion
 **Summary judgment: USABLE**
 
-The outlined ERC4626 Vaults should work well with Balancer pools. Upgradeability is guarded by Aave governance and the Vaults implement the required interfaces with fork tests passing as can be seen [here]().
+The outlined ERC4626 Vaults should work well with Balancer pools. Upgradeability is guarded by Aave governance and the Vaults implement the required interfaces with fork tests passing as can be seen [here](https://github.com/balancer/balancer-v3-monorepo/pull/1171).

--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -1,0 +1,57 @@
+# ERC4626 Vault: `StataTokenV2`
+
+## Details
+- Reviewed by: @mkflow27
+- Checked by: @\<GitHub handle of secondary reviewer\>
+- Deployed at:
+    - [gnosis:0x773cda0cade2a3d86e6d4e30699d40bb95174ff2](https://gnosisscan.io/address/0x773cda0cade2a3d86e6d4e30699d40bb95174ff2#code)
+    - [gnosis:0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644](https://gnosisscan.io/address/0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644)
+    - [gnosis:0x51350d88c1bd32cc6a79368c9fb70373fb71f375](https://gnosisscan.io/address/0x51350d88c1bd32cc6a79368c9fb70373fb71f375)
+- Audit report(s):
+    - [StatATokenV2 audits](https://github.com/aave-dao/aave-v3-origin/blob/067d29eb75115179501edc4316d125d9773f7928/audits/11-09-2024_Certora_StataTokenV2.pdf)
+
+## Context
+A 4626 Vault which wrapps aTokens in order to translate the rebasing nature of yield accrual into a non-rebasing value accrual.
+
+## Review Checklist: Bare Minimum Compatibility
+Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
+
+- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults.
+- [x] The required Vault implements the required operational ERC4626 Interface
+
+## Review Checklist: Common Findings
+Each of the items below represents a common red flag found in Rate Provider contracts.
+
+If none of these is checked, then this might be a pretty great Rate Provider! If any of these is checked, we must thoroughly elaborate on the conditions that lead to the potential issue. Decision points are not binary; a Rate Provider can be safe despite these boxes being checked. A check simply indicates that thorough vetting is required in a specific area, and this vetting should be used to inform a holistic analysis of the Rate Provider.
+
+### Administrative Privileges
+- [x] The ERC4626 Vault is upgradeable. 
+
+    #### Wrapped Aave Gnosis wstETH - 0x773CDA0CADe2A3d86E6D4e30699d40bB95174ff2
+    - upgradeable component: `StataTokenV2` ([gnosis:0x773CDA0CADe2A3d86E6D4e30699d40bB95174ff2](https://gnosisscan.io/address/0x773CDA0CADe2A3d86E6D4e30699d40bB95174ff2#readProxyContract))
+    - admin address: [gnosis:0x1dF462e2712496373A347f8ad10802a5E95f053D](https://gnosisscan.io/address/0x1dF462e2712496373A347f8ad10802a5E95f053D)
+    - admin type: Aave governance system.
+        - multisig timelock? YES: 24 hours.
+
+    #### Wrapped Aave Gnosis GNO - 0x7c16F0185A26Db0AE7a9377f23BC18ea7ce5d644
+    - upgradeable component: `StataTokenV2` ([gnosis:0x7c16F0185A26Db0AE7a9377f23BC18ea7ce5d644](https://gnosisscan.io/address/0x7c16F0185A26Db0AE7a9377f23BC18ea7ce5d644))
+    - admin address: [gnosis:0x1dF462e2712496373A347f8ad10802a5E95f053D](https://gnosisscan.io/address/0x1dF462e2712496373A347f8ad10802a5E95f053D)
+    - admin type: Aave governance system.
+        - multisig timelock? YES: 24 hours.
+
+    #### Wrapped Aave Gnosis USDCe - 0x51350d88c1bd32Cc6A79368c9Fb70373Fb71F375
+    - upgradeable component: `StataTokenV2` ([gnosis:0x51350d88c1bd32Cc6A79368c9Fb70373Fb71F375](https://gnosisscan.io/address/0x51350d88c1bd32Cc6A79368c9Fb70373Fb71F375))
+    - admin address: [gnosis:0x1dF462e2712496373A347f8ad10802a5E95f053D](https://gnosisscan.io/address/0x1dF462e2712496373A347f8ad10802a5E95f053D)
+    - admin type: Aave governance system.
+        - multisig timelock? YES: 24 hours.
+
+### Common Manipulation Vectors
+- [ ] The ERC4626 Vault is susceptible to donation attacks.
+
+## Additional Findings
+To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
+
+## Conclusion
+**Summary judgment: USABLE**
+
+The outlined ERC4626 Vaults should work well with Balancer pools. Upgradeability is guarded by Aave governance and the Vaults implement the required interfaces with fork tests passing as can be seen [here]().

--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -54,4 +54,7 @@ To save time, we do not bother pointing out low-severity/informational issues or
 ## Conclusion
 **Summary judgment: USABLE**
 
-The outlined ERC4626 Vaults should work well with Balancer pools. Upgradeability is guarded by Aave governance and the Vaults implement the required interfaces with fork tests passing as can be seen [here](https://github.com/balancer/balancer-v3-monorepo/pull/1171).
+The outlined ERC4626 Vaults should work well with Balancer pools. Upgradeability is guarded by Aave governance and the Vaults implement the required interfaces with fork tests passing as can be seen here:
+- [Aave's GNO](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/gnosis/ERC4626GnosisAaveGno.t.sol)
+- [Aave's WstEth](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/gnosis/ERC4626GnosisAaveWstEth.t.sol)
+- [Aave's USDC.e](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/gnosis/ERC4626GnosisAaveUsdce.t.sol)

--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -16,7 +16,7 @@ A 4626 Vault which wrapps aTokens in order to translate the rebasing nature of y
 ## Review Checklist: Bare Minimum Compatibility
 Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
 
-- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults, which can be found [here](https://github.com/balancer/balancer-v3-monorepo/pull/1171).
+- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults, which can be found [here](https://github.com/balancer/balancer-v3-erc4626-tests/tree/main/test).
 - [x] The required Vault implements the required operational ERC4626 Interface
 
 ## Review Checklist: Common Findings

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -21,5 +21,35 @@
             "review": "./AaveV3.md",
             "warnings": []
         }
+    },
+    "gnosis":{
+        "0x773cda0cade2a3d86e6d4e30699d40bb95174ff2":{
+            "asset":"0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
+            "name": "Aave Gnosis wstETH",
+            "summary": "safe",
+            "review": "../rate-providers/statATokenv2RateProvider.md",
+            "warnings": []
+        },
+        "0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644":{
+            "asset":"0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
+            "name": "Aave Gnosis GNO",
+            "summary": "safe",
+            "review": "../rate-providers/statATokenv2RateProvider.md",
+            "warnings": []
+        },
+        "0xaf204776c7245bf4147c2612bf6e5972ee483701":{
+            "asset":"0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+            "name": "sDAI",
+            "summary": "safe",
+            "review": "../rate-providers/statATokenv2RateProvider.md",
+            "warnings": []
+        },
+        "0x51350d88c1bd32cc6a79368c9fb70373fb71f375":{
+            "asset":"0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0",
+            "name": "Aave Gnosis USDCe",
+            "summary": "safe",
+            "review": "../rate-providers/statATokenv2RateProvider.md",
+            "warnings": []
+        }
     }
 }

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -1,65 +1,64 @@
 {
-    "mainnet":{
-        "0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E":{
-            "asset":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-            "name": "Aave Ethereum USDC",
-            "summary": "safe",
-            "review": "../rate-providers/MarketRateTransformerRateProviders.md",
-            "warnings": []
-        }
-    },
-    "gnosis":{
-        "0x773cda0cade2a3d86e6d4e30699d40bb95174ff2":{
-            "asset":"0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
-            "name": "Aave Gnosis wstETH",
-            "summary": "safe",
-            "review": "../rate-providers/statATokenv2RateProvider.md",
-            "warnings": []
-        },
-        "0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644":{
-            "asset":"0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
-            "name": "Aave Gnosis GNO",
-            "summary": "safe",
-            "review": "../rate-providers/statATokenv2RateProvider.md",
-            "warnings": []
-        },
-        "0xaf204776c7245bf4147c2612bf6e5972ee483701":{
-            "asset":"0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-            "name": "sDAI",
-            "summary": "safe",
-            "review": "../rate-providers/statATokenv2RateProvider.md",
-            "warnings": []
-        },
-        "0x51350d88c1bd32cc6a79368c9fb70373fb71f375":{
-            "asset":"0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0",
-            "name": "Aave Gnosis USDCe",
-            "summary": "safe",
-            "review": "../rate-providers/statATokenv2RateProvider.md",
-            "warnings": []
-        }
-
-    },
-    "sepolia":{
-        "0xDE46e43F46ff74A23a65EBb0580cbe3dFE684a17":{
-            "asset":"0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
-            "name": "Static Aave Ethereum DAI",
-            "summary": "safe",
-            "review": "./AaveV3.md",
-            "warnings": []
-        },
-        "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8":{
-            "asset":"0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
-            "name": "Static Aave Ethereum USDT",
-            "summary": "safe",
-            "review": "./AaveV3.md",
-            "warnings": []
-        },
-        "0x978206fAe13faF5a8d293FB614326B237684B750":{
-            "asset":"0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0",
-            "name": "Static Aave Ethereum USDC",
-            "summary": "safe",
-            "review": "./AaveV3.md",
-            "warnings": []
-        }
+  "mainnet": {
+    "0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E": {
+      "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "name": "Aave Ethereum USDC",
+      "summary": "safe",
+      "review": "../rate-providers/MarketRateTransformerRateProviders.md",
+      "warnings": []
     }
+  },
+  "gnosis": {
+    "0x773cda0cade2a3d86e6d4e30699d40bb95174ff2": {
+      "asset": "0x6C76971f98945AE98dD7d4DFcA8711ebea946eA6",
+      "name": "Aave Gnosis wstETH",
+      "summary": "safe",
+      "review": "./StatATokenV2Review.md",
+      "warnings": []
+    },
+    "0x7c16f0185a26db0ae7a9377f23bc18ea7ce5d644": {
+      "asset": "0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb",
+      "name": "Aave Gnosis GNO",
+      "summary": "safe",
+      "review": "./StatATokenV2Review.md",
+      "warnings": []
+    },
+    "0xaf204776c7245bf4147c2612bf6e5972ee483701": {
+      "asset": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+      "name": "sDAI",
+      "summary": "",
+      "review": "",
+      "warnings": []
+    },
+    "0x51350d88c1bd32cc6a79368c9fb70373fb71f375": {
+      "asset": "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0",
+      "name": "Aave Gnosis USDCe",
+      "summary": "safe",
+      "review": "./StatATokenV2Review.md",
+      "warnings": []
+    }
+  },
+  "sepolia": {
+    "0xDE46e43F46ff74A23a65EBb0580cbe3dFE684a17": {
+      "asset": "0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
+      "name": "Static Aave Ethereum DAI",
+      "summary": "safe",
+      "review": "./AaveV3.md",
+      "warnings": []
+    },
+    "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8": {
+      "asset": "0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
+      "name": "Static Aave Ethereum USDT",
+      "summary": "safe",
+      "review": "./AaveV3.md",
+      "warnings": []
+    },
+    "0x978206fAe13faF5a8d293FB614326B237684B750": {
+      "asset": "0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0",
+      "name": "Static Aave Ethereum USDC",
+      "summary": "safe",
+      "review": "./AaveV3.md",
+      "warnings": []
+    }
+  }
 }

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -1,24 +1,10 @@
 {
-    "sepolia":{
-        "0xDE46e43F46ff74A23a65EBb0580cbe3dFE684a17":{
-            "asset":"0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
-            "name": "Static Aave Ethereum DAI",
+    "mainnet":{
+        "0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E":{
+            "asset":"0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "name": "Aave Ethereum USDC",
             "summary": "safe",
-            "review": "./AaveV3.md",
-            "warnings": []
-        },
-        "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8":{
-            "asset":"0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
-            "name": "Static Aave Ethereum USDT",
-            "summary": "safe",
-            "review": "./AaveV3.md",
-            "warnings": []
-        },
-        "0x978206fAe13faF5a8d293FB614326B237684B750":{
-            "asset":"0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0",
-            "name": "Static Aave Ethereum USDC",
-            "summary": "safe",
-            "review": "./AaveV3.md",
+            "review": "../rate-providers/MarketRateTransformerRateProviders.md",
             "warnings": []
         }
     },
@@ -49,6 +35,30 @@
             "name": "Aave Gnosis USDCe",
             "summary": "safe",
             "review": "../rate-providers/statATokenv2RateProvider.md",
+            "warnings": []
+        }
+
+    },
+    "sepolia":{
+        "0xDE46e43F46ff74A23a65EBb0580cbe3dFE684a17":{
+            "asset":"0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
+            "name": "Static Aave Ethereum DAI",
+            "summary": "safe",
+            "review": "./AaveV3.md",
+            "warnings": []
+        },
+        "0x94a9d9ac8a22534e3faca9f4e7f2e2cf85d5e4c8":{
+            "asset":"0xff34b3d4aee8ddcd6f9afffb6fe49bd371b8a357",
+            "name": "Static Aave Ethereum USDT",
+            "summary": "safe",
+            "review": "./AaveV3.md",
+            "warnings": []
+        },
+        "0x978206fAe13faF5a8d293FB614326B237684B750":{
+            "asset":"0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0",
+            "name": "Static Aave Ethereum USDC",
+            "summary": "safe",
+            "review": "./AaveV3.md",
             "warnings": []
         }
     }

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -26,9 +26,9 @@
     "0xaf204776c7245bf4147c2612bf6e5972ee483701": {
       "asset": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
       "name": "sDAI",
-      "summary": "",
-      "review": "",
-      "warnings": []
+      "summary": "safe",
+      "review": "./SavingsDAIRateProviderGnosis.md",
+      "warnings": ["buffer"]
     },
     "0x51350d88c1bd32cc6a79368c9fb70373fb71f375": {
       "asset": "0x2a22f9c3b484c3629090FeED35F17Ff8F88f76F0",

--- a/erc4626/sDaiReview.md
+++ b/erc4626/sDaiReview.md
@@ -13,7 +13,7 @@ Savings DAI (`sDAI`) is a yield-bearing token representing `DAI` deposited in Ma
 ## Review Checklist: Bare Minimum Compatibility
 Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
 
-- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults, which can be found [here](https://github.com/balancer/balancer-v3-monorepo/pull/1172).
+- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults, which can be found [here](https://github.com/balancer/balancer-v3-erc4626-tests/tree/main/test).
 - [x] The required Vault implements the required operational ERC4626 Interface
 
 ## Review Checklist: Common Findings

--- a/erc4626/sDaiReview.md
+++ b/erc4626/sDaiReview.md
@@ -52,5 +52,5 @@ To save time, we do not bother pointing out low-severity/informational issues or
 ## Conclusion
 **Summary judgment: USABLE**
 
-The outlined ERC4626 Vaults should work well with Balancer pools.The Vault implements the required interfaces. Fork tests passing as can be seen [here](https://github.com/balancer/balancer-v3-monorepo/pull/1171). Users should take into account the developers comments as part of the test-pr which state
+The outlined ERC4626 Vaults should work well with Balancer pools.The Vault implements the required interfaces. Fork tests passing as can be seen [here](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/gnosis/ERC4626GnosisSDai.t.sol). Users should take into account the developers comments as part of the test-pr which state
 > sDAI requires a special ERC4626 test, due to the token unusual behavior: every deposit devalues a bit the wrapped tokens, so a user may not be able to withdraw the amount that it deposited, only part of it. When interacting with boosted pools, this behavior is ok, but it's a warning when initializing a buffer or adding liquidity to a buffer: that buffer may leak value.

--- a/erc4626/sDaiReview.md
+++ b/erc4626/sDaiReview.md
@@ -2,7 +2,7 @@
 
 ## Details
 - Reviewed by: @mkflow27
-- Checked by: @\<GitHub handle of secondary reviewer\>
+- Checked by: @danielmkm
 - Deployed at:
     - [gnosis:0xaf204776c7245bF4147c2612BF6e5972Ee483701](https://gnosisscan.io/address/0xaf204776c7245bf4147c2612bf6e5972ee483701)
 - Audit report(s):

--- a/erc4626/sDaiReview.md
+++ b/erc4626/sDaiReview.md
@@ -1,0 +1,56 @@
+# ERC4626 Vault: `StataTokenV2`
+
+## Details
+- Reviewed by: @mkflow27
+- Checked by: @\<GitHub handle of secondary reviewer\>
+- Deployed at:
+    - [gnosis:0xaf204776c7245bF4147c2612BF6e5972Ee483701](https://gnosisscan.io/address/0xaf204776c7245bf4147c2612bf6e5972ee483701)
+- Audit report(s):
+    - [ChainSecurity - Savings Dai](https://github.com/makerdao/sdai/blob/0377fa3a3e8af846f7511fb7cfe18c2e276e9dfa/audits/ChainSecurity_Oazo_Apps_Limited_Savings_Dai_audit_1.pdf)
+
+## Context
+Savings DAI (`sDAI`) is a yield-bearing token representing `DAI` deposited in Maker's DAI Saving Rate (DSR) module. This review covers the Gnosis Chain deployment, so it uses `WXDAI` (wrapped xDAI) deposits and accrues yield via a bridge to Ethereum mainnet.
+## Review Checklist: Bare Minimum Compatibility
+Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
+
+- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults, which can be found [here](https://github.com/balancer/balancer-v3-monorepo/pull/1172).
+- [x] The required Vault implements the required operational ERC4626 Interface
+
+## Review Checklist: Common Findings
+Each of the items below represents a common red flag found in Rate Provider contracts.
+
+If none of these is checked, then this might be a pretty great Rate Provider! If any of these is checked, we must thoroughly elaborate on the conditions that lead to the potential issue. Decision points are not binary; a Rate Provider can be safe despite these boxes being checked. A check simply indicates that thorough vetting is required in a specific area, and this vetting should be used to inform a holistic analysis of the Rate Provider.
+
+### Administrative Privileges
+- [] The ERC4626 Vault is upgradeable. 
+
+### Common Manipulation Vectors
+- [x] The ERC4626 Vault is susceptible to donation attacks.
+
+The Ethereum mainnet deployment of `sDAI` is not susceptible to donation attacks because it utilizes on-chain pricing logic from the DSR (DAI Savings Rate) module. However, the Gnosis Chain deployment is indeed susceptible to donation attacks because it utilizes a standard ERC-4626 implementation that calls `_asset.balanceOf(address(this))`.
+
+```solidity
+/** @dev See {IERC4626-totalAssets}. */
+function totalAssets() public view virtual returns (uint256) {
+    return _asset.balanceOf(address(this));
+}
+
+/** @dev See {IERC4626-convertToShares}. */
+function convertToShares(uint256 assets) public view virtual returns (uint256) {
+    return _convertToShares(assets, Math.Rounding.Floor);
+}
+
+/** @dev See {IERC4626-convertToAssets}. */
+function convertToAssets(uint256 shares) public view virtual returns (uint256) {
+    return _convertToAssets(shares, Math.Rounding.Floor);
+}
+```
+
+## Additional Findings
+To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
+
+## Conclusion
+**Summary judgment: USABLE**
+
+The outlined ERC4626 Vaults should work well with Balancer pools.The Vault implements the required interfaces. Fork tests passing as can be seen [here](https://github.com/balancer/balancer-v3-monorepo/pull/1171). Users should take into account the developers comments as part of the test-pr which state
+> sDAI requires a special ERC4626 test, due to the token unusual behavior: every deposit devalues a bit the wrapped tokens, so a user may not be able to withdraw the amount that it deposited, only part of it. When interacting with boosted pools, this behavior is ok, but it's a warning when initializing a buffer or adding liquidity to a buffer: that buffer may leak value.

--- a/erc4626/sDaiReview.md
+++ b/erc4626/sDaiReview.md
@@ -1,4 +1,4 @@
-# ERC4626 Vault: `StataTokenV2`
+# ERC4626 Vault: `SavingsXDai`
 
 ## Details
 - Reviewed by: @mkflow27


### PR DESCRIPTION
- add gnosis and mainnet tokenized vaults as per code review
- checked vault and asset as per PROD boosted pools in [test UI](https://test.balancer.fi/pools?networks=MAINNET,GNOSIS&protocolVersion=3)
- please cross-check correct setup. Goal is for tokenized vault warnings to go away

IMPORTANT: main registry with ERC4626 rate providers still needs to be populated to register boosted pool rate providers as well!

Example: [Boosetd pool with waGNO and wstETH tokenized vaults](https://test.balancer.fi/pools/gnosis/v3/0x272d6be442e30d7c87390edeb9b96f1e84cecd8d)
![image](https://github.com/user-attachments/assets/62188d74-6092-4b1d-80d9-abcd4c3d1bf3)
