### PR TITLE
Supporting-Aave-ETH-USDe

### DIFF
--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -94,6 +94,12 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
         - admin type: Aave governance system.
             - multisig timelock? YES: 24 hours.
 
+    #### Wrapped Aave Lido Ethereum GHO - 0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C
+    - upgradeable component: `StataTokenV2` ([ethereum:0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C](https://etherscan.io/address/0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C#readProxyContract))
+    - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
+
 ### Common Manipulation Vectors
 - [ ] The ERC4626 Vault is susceptible to donation attacks.
 

--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -13,6 +13,7 @@
     - [ethereum:0x7Bc3485026Ac48b6cf9BaF0A377477Fff5703Af8](https://etherscan.io/address/0x7bc3485026ac48b6cf9baf0a377477fff5703af8#readProxyContract)
     - [ethereum:0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9](https://etherscan.io/token/0x0fe906e030a44ef24ca8c7dc7b7c53a6c4f00ce9#readProxyContract)
     - [ethereum:0x775F661b0bD1739349b9A2A3EF60be277c5d2D29](https://etherscan.io/token/0x775f661b0bd1739349b9a2a3ef60be277c5d2d29#readProxyContract)
+    - 
 - Audit report(s):
     - [StatATokenV2 audits](https://github.com/aave-dao/aave-v3-origin/blob/067d29eb75115179501edc4316d125d9773f7928/audits/11-09-2024_Certora_StataTokenV2.pdf)
 
@@ -87,6 +88,11 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
         - admin type: Aave governance system.
             - multisig timelock? YES: 24 hours.
     
+    #### Wrapped Aave Ethereum USDe - 0x5F9D59db355b4A60501544637b00e94082cA575b
+    - upgradeable component: `StataTokenV2` ([ethereum:0x5F9D59db355b4A60501544637b00e94082cA575b](https://etherscan.io/address/0x5F9D59db355b4A60501544637b00e94082cA575b#readProxyContract))
+    - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
 
 ### Common Manipulation Vectors
 - [ ] The ERC4626 Vault is susceptible to donation attacks.

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -65,7 +65,14 @@
     },
     "0x5F9D59db355b4A60501544637b00e94082cA575b": {
       "asset": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
-      "name": "Wrapped Aave Ethereum USDT",
+      "name": "Wrapped Aave Ethereum USDe",
+      "summary": "safe",
+      "review": "./StatATokenV2Review.md",
+      "warnings": []
+    },
+    "0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C": {
+      "asset": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f",
+      "name": "Wrapped Aave Lido Ethereum GHO",
       "summary": "safe",
       "review": "./StatATokenV2Review.md",
       "warnings": []

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -62,6 +62,13 @@
       "summary": "safe",
       "review": "./StatATokenV2Review.md",
       "warnings": []
+    },
+    "0x5F9D59db355b4A60501544637b00e94082cA575b": {
+      "asset": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+      "name": "Wrapped Aave Ethereum USDT",
+      "summary": "safe",
+      "review": "./StatATokenV2Review.md",
+      "warnings": []
     }
   },
   "gnosis": {

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1883,6 +1883,24 @@
           "implementationReviewed": "0x752d55d62a94658eac08eae42deda902b69b0e76"
         }
       ]
+    },
+    "0xdB44A0223604ABAD704C4bCDDAAd88b101953246": {
+      "asset": "0x5F9D59db355b4A60501544637b00e94082cA575b",
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./statATokenv2RateProvider.md",
+      "warnings": [""],
+      "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x5F9D59db355b4A60501544637b00e94082cA575b",
+          "implementationReviewed": "0x487c2C53c0866F0A73ae317bD1A28F63ADcD9aD1"
+        },
+        {
+          "entrypoint": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+          "implementationReviewed": "0xeF434E4573b90b6ECd4a00f4888381e4D0CC5Ccd"
+        }
+      ]
     }
   },
   "fantom": {

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1901,6 +1901,24 @@
           "implementationReviewed": "0xeF434E4573b90b6ECd4a00f4888381e4D0CC5Ccd"
         }
       ]
+    },
+    "0x851b73c4BFd5275D47FFf082F9e8B4997dCCB253": {
+      "asset": "0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C",
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./statATokenv2RateProvider.md",
+      "warnings": [""],
+      "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C",
+          "implementationReviewed": "0x487c2C53c0866F0A73ae317bD1A28F63ADcD9aD1"
+        },
+        {
+          "entrypoint": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+          "implementationReviewed": "0xeF434E4573b90b6ECd4a00f4888381e4D0CC5Ccd"
+        }
+      ]
     }
   },
   "fantom": {

--- a/rate-providers/statATokenv2RateProvider.md
+++ b/rate-providers/statATokenv2RateProvider.md
@@ -9,6 +9,7 @@
     - USDT [ethereum:0xEdf63cce4bA70cbE74064b7687882E71ebB0e988](https://etherscan.io/address/0xEdf63cce4bA70cbE74064b7687882E71ebB0e988#code)
     - Lido wETH [ethereum:0xf4b5D1C22F35a460b91edD7F33Cefe619E2fAaF4](https://etherscan.io/address/0xf4b5D1C22F35a460b91edD7F33Cefe619E2fAaF4#code)
     - USDe [ethereum:0xdB44A0223604ABAD704C4bCDDAAd88b101953246](https://etherscan.io/address/0xdB44A0223604ABAD704C4bCDDAAd88b101953246#code)
+    - Lido GHO [ethereum:0x851b73c4BFd5275D47FFf082F9e8B4997dCCB253](https://etherscan.io/address/0x851b73c4BFd5275D47FFf082F9e8B4997dCCB253#code)    
 
     - wETH [gnosis:0x0008A59C1d2E5922790C929ea432ed02D4D3323A](https://gnosisscan.io/address/0x0008A59C1d2E5922790C929ea432ed02D4D3323A#readContract)
     - GNO [gnosis:0xbbb4966335677Ea24F7B86DC19a423412390e1fb](https://gnosisscan.io/address/0xbbb4966335677Ea24F7B86DC19a423412390e1fb#code)
@@ -77,6 +78,16 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 
    - [ethereum:0xdB44A0223604ABAD704C4bCDDAAd88b101953246](https://etherscan.io/address/0xdB44A0223604ABAD704C4bCDDAAd88b101953246#code)
         - upgradeable component: `StataTokenV2` ([ethereum:0x5F9D59db355b4A60501544637b00e94082cA575b](https://etherscan.io/address/0x5F9D59db355b4A60501544637b00e94082cA575b#readProxyContract))
+        - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
+        - upgradeable component: `Pool` ([ethereum:0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2](https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#readProxyContract))
+        - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours
+
+    - [ethereum:0x851b73c4BFd5275D47FFf082F9e8B4997dCCB253](https://etherscan.io/address/0x851b73c4BFd5275D47FFf082F9e8B4997dCCB253#code)
+        - upgradeable component: `StataTokenV2` ([ethereum:0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C](https://etherscan.io/address/0xC71Ea051a5F82c67ADcF634c36FFE6334793D24C#readProxyContract))
         - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
         - admin type: Aave governance system.
             - multisig timelock? YES: 24 hours.

--- a/rate-providers/statATokenv2RateProvider.md
+++ b/rate-providers/statATokenv2RateProvider.md
@@ -8,6 +8,7 @@
     - USDC [ethereum:0x8f4E8439b970363648421C692dd897Fb9c0Bd1D9](https://etherscan.io/address/0x8f4E8439b970363648421C692dd897Fb9c0Bd1D9#code)
     - USDT [ethereum:0xEdf63cce4bA70cbE74064b7687882E71ebB0e988](https://etherscan.io/address/0xEdf63cce4bA70cbE74064b7687882E71ebB0e988#code)
     - Lido wETH [ethereum:0xf4b5D1C22F35a460b91edD7F33Cefe619E2fAaF4](https://etherscan.io/address/0xf4b5D1C22F35a460b91edD7F33Cefe619E2fAaF4#code)
+    - USDe [ethereum:0xdB44A0223604ABAD704C4bCDDAAd88b101953246](https://etherscan.io/address/0xdB44A0223604ABAD704C4bCDDAAd88b101953246#code)
 
     - wETH [gnosis:0x0008A59C1d2E5922790C929ea432ed02D4D3323A](https://gnosisscan.io/address/0x0008A59C1d2E5922790C929ea432ed02D4D3323A#readContract)
     - GNO [gnosis:0xbbb4966335677Ea24F7B86DC19a423412390e1fb](https://gnosisscan.io/address/0xbbb4966335677Ea24F7B86DC19a423412390e1fb#code)
@@ -66,6 +67,16 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 
     - [ethereum:0xf4b5D1C22F35a460b91edD7F33Cefe619E2fAaF4](https://etherscan.io/address/0xf4b5D1C22F35a460b91edD7F33Cefe619E2fAaF4#code)
         - upgradeable component: `StataTokenV2` ([ethereum:0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9](https://etherscan.io/address/0x0FE906e030a44eF24CA8c7dC7B7c53A6C4F00ce9#readProxyContract))
+        - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
+        - upgradeable component: `Pool` ([ethereum:0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2](https://etherscan.io/address/0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2#readProxyContract))
+        - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours
+
+   - [ethereum:0xdB44A0223604ABAD704C4bCDDAAd88b101953246](https://etherscan.io/address/0xdB44A0223604ABAD704C4bCDDAAd88b101953246#code)
+        - upgradeable component: `StataTokenV2` ([ethereum:0x5F9D59db355b4A60501544637b00e94082cA575b](https://etherscan.io/address/0x5F9D59db355b4A60501544637b00e94082cA575b#readProxyContract))
         - admin address: [ethereum:0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A#code)
         - admin type: Aave governance system.
             - multisig timelock? YES: 24 hours.


### PR DESCRIPTION
Adds ERC4626 and rate provider registration based on StataV2 wrappers for Ethena's USDe. Respective pool: https://balancer.fi/pools/ethereum/v3/0xc1D48bB722a22Cc6Abf19faCbE27470F08B3dB8c