### PR TITLE
MorphoV1.1-Coinshift-USDC-wUSDL-Additions

### DIFF
--- a/erc4626/MorphoVaults/V1-Incompatible-Gauntlet.md
+++ b/erc4626/MorphoVaults/V1-Incompatible-Gauntlet.md
@@ -35,7 +35,7 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
 
 ## Conclusion
-**Summary judgment: USABLE**
+**Summary judgment: UNUSABLE**
 
-The outlined ERC4626 Vaults should work well with Balancer pools. The Vaults implement the required interfaces with fork tests passing as can be seen at:
+The outlined ERC4626 Vaults will not work well with Balancer pools due to a flash loan incompatibility on Morpho Vaults . The Vaults implement the required interfaces with fork tests passing as can be seen at:
     - [Morpho's Gauntlet Weth](https://github.com/balancer/balancer-v3-erc4626-tests/blob/f6245bfe043759ea17d7282ada58871dc12f8fcc/test/mainnet/ERC4626MainnetMorphoGauntletWeth.t.sol#L20)

--- a/erc4626/MorphoVaults/V1-incompatible-Steakhouse.md
+++ b/erc4626/MorphoVaults/V1-incompatible-Steakhouse.md
@@ -36,10 +36,9 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
 
 ## Conclusion
-**Summary judgment: USABLE**
+**Summary judgment: UNUSABLE**
 
-The outlined ERC4626 Vaults should work well with Balancer pools. The Vaults implement the required interfaces with fork tests passing as can be seen at:
-- [Morpho's Steakhouse USDC](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol)
+The outlined ERC4626 Vaults will not work well with Balancer pools due to a flash loan incompatibility on Morpho Vaults . The Vaults implement the required interfaces with fork tests passing as can be seen at:- [Morpho's Steakhouse USDC](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDC.t.sol)
 - [Morpho's Steakhouse USDT](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/mainnet/ERC4626MainnetMorphoSteakhouseUSDT.t.sol)
 - [Morpho's Steakhouse wUSDL](https://github.com/balancer/balancer-v3-erc4626-tests/blob/main/test/mainnet/ERC4626MainnetMorphoSteakhouseWUSDL.t.sol)
 

--- a/erc4626/MorphoVaults/V1.1-Steakhouse.md
+++ b/erc4626/MorphoVaults/V1.1-Steakhouse.md
@@ -1,0 +1,39 @@
+# ERC4626 Vault: `MetaMorpho`
+
+## Details
+- Reviewed by: @mkflow27
+- Checked by: @danielmkm
+- Deployed at:
+    - [ethereum:https://etherscan.io/address/0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330](https://etherscan.io/address/0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330)
+    - [ethereum:https://etherscan.io/address/0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1](https://etherscan.io/address/0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1)
+- Audit report(s):
+    - [Security Reviews & Formal Verifications](https://docs.morpho.org/security-reviews/)
+
+## Context
+A 4626 Vault which wraps underlying tokens in MetaMorpho vaults in order for vault curators to earn liquidity providers additional yield on their assets.
+
+## Review Checklist: Bare Minimum Compatibility
+Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
+
+- [x] Tests based on the [balancer-v3-monorepo](https://github.com/balancer/balancer-v3-monorepo/tree/main/pkg/vault/test/foundry/fork) pass for the given ERC4626 vaults.
+- [x] The required Vault implements the required operational ERC4626 Interface
+
+## Review Checklist: Common Findings
+Each of the items below represents a common red flag found in Rate Provider contracts.
+
+If none of these is checked, then this might be a pretty great Rate Provider! If any of these is checked, we must thoroughly elaborate on the conditions that lead to the potential issue. Decision points are not binary; a Rate Provider can be safe despite these boxes being checked. A check simply indicates that thorough vetting is required in a specific area, and this vetting should be used to inform a holistic analysis of the Rate Provider.
+
+### Administrative Privileges
+- [] The ERC4626 Vault is upgradeable.
+    - note: Upgradeability remarks for rate relevant aspects can be found in the corresponding rate provider review. 
+
+### Common Manipulation Vectors
+- [] The ERC4626 Vault is susceptible to donation attacks.
+
+## Additional Findings
+To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
+
+## Conclusion
+**Summary judgment: USABLE**
+
+The outlined ERC4626 Vaults should work well with Balancer pools. The Vaults implement the required interfaces with fork tests passing as can be seen at:

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -4,28 +4,28 @@
       "asset": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "name": "MetaMorpho Gauntlet wETH Prime",
       "summary": "unsafe",
-      "review": "./MorphoVaults/Gauntlet.md",
+      "review": "./MorphoVaults/V1-Incompatible-Gauntlet.md",
       "warnings": []
     },
     "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB": {
       "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "name": "MetaMorpho Steakhouse SteakUSDC",
       "summary": "unsafe",
-      "review": "./MorphoVaults/Steakhouse.md",
+      "review": "./MorphoVaults/V1-incompatible-Steakhouse.md",
       "warnings": []
     },
     "0xbEef047a543E45807105E51A8BBEFCc5950fcfBa": {
       "asset": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "name": "MetaMorpho Steakhouse SteakUSDT",
       "summary": "unsafe",
-      "review": "./MorphoVaults/Steakhouse.md",
+      "review": "./MorphoVaults/V1-incompatible-Steakhouse.md",
       "warnings": []
     },
     "0xbEEFC01767ed5086f35deCb6C00e6C12bc7476C1": {
       "asset": "0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559",
       "name": "MetaMorpho Coinshift-Steakhouse csUSDL",
       "summary": "unsafe",
-      "review": "./MorphoVaults/Steakhouse.md",
+      "review": "./MorphoVaults/V1-incompatible-Steakhouse.md",
       "warnings": []
     },
     "0xD4fa2D31b7968E448877f69A96DE69f5de8cD23E": {
@@ -67,14 +67,14 @@
       "asset": "0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559",
       "name": "MetaMorpho v1.1 Coinshift-Steakhouse csUSDL",
       "summary": "safe",
-      "review": "./MorphoVaults/Steakhouse.md",
+      "review": "./MorphoVaults/V1.1-Steakhouse.md",
       "warnings": []
     },
     "0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330": {
       "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "name": "MetaMorpho v1.1 Coinshift-Steakhouse csUSDC",
       "summary": "safe",
-      "review": "./MorphoVaults/Steakhouse.md",
+      "review": "./MorphoVaults/V1.1-Steakhouse.md",
       "warnings": []
     }
   },

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -3,28 +3,28 @@
     "0x2371e134e3455e0593363cBF89d3b6cf53740618": {
       "asset": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "name": "MetaMorpho Gauntlet wETH Prime",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoVaults/Gauntlet.md",
       "warnings": []
     },
     "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB": {
       "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "name": "MetaMorpho Steakhouse SteakUSDC",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoVaults/Steakhouse.md",
       "warnings": []
     },
     "0xbEef047a543E45807105E51A8BBEFCc5950fcfBa": {
       "asset": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "name": "MetaMorpho Steakhouse SteakUSDT",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoVaults/Steakhouse.md",
       "warnings": []
     },
     "0xbEEFC01767ed5086f35deCb6C00e6C12bc7476C1": {
       "asset": "0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559",
       "name": "MetaMorpho Coinshift-Steakhouse csUSDL",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoVaults/Steakhouse.md",
       "warnings": []
     },
@@ -61,6 +61,20 @@
       "name": "Wrapped Aave Ethereum Lido wstETH",
       "summary": "safe",
       "review": "./StatATokenV2Review.md",
+      "warnings": []
+    },
+    "0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1": {
+      "asset": "0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559",
+      "name": "MetaMorpho v1.1 Coinshift-Steakhouse csUSDL",
+      "summary": "safe",
+      "review": "./MorphoVaults/Steakhouse.md",
+      "warnings": []
+    },
+    "0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330": {
+      "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "name": "MetaMorpho v1.1 Coinshift-Steakhouse csUSDC",
+      "summary": "safe",
+      "review": "./MorphoVaults/Steakhouse.md",
       "warnings": []
     }
   },

--- a/rate-providers/MarketRateTransformerRateProviders.md
+++ b/rate-providers/MarketRateTransformerRateProviders.md
@@ -16,6 +16,10 @@
         - ERC4626RateProvider: aave wsteth market
         - ERC4626Vault's `asset` rate provider: Wrapped Staked Eth
 
+    - csUSDL v1.1 (Steakhouse) [ethereum:0x9062a576D3e6Cf6999e99e405608063033c4CFF6](https://etherscan.io/address/0x9062a576D3e6Cf6999e99e405608063033c4CFF6#code)
+        - ERC4626RateProvider: MetaMorphoV1_1
+        - ERC4626Vault's `asset` rate provider: Wrapped USDL (wUSDL) ERC4626 Rate Provider
+
 - Audit report(s):
     - [Formal Verification Report For StaticAToken](https://github.com/aave-dao/aave-v3-origin/blob/067d29eb75115179501edc4316d125d9773f7928/audits/11-09-2024_Certora_StataTokenV2.pdf)
     - [Security Reviews & Formal Verifications](https://docs.morpho.org/security-reviews/)
@@ -25,7 +29,7 @@
 Aave markets Lido a-wstETH & a-wstETH
 The ERC4626 RateProvider fetches the rate of Static Aave Tokens in terms of USDC or USDT. The exchange rate is provided by the Aave V3 `POOL` and fetched via `getReserveNormalizedIncome` from the pool and wrapped as part of the `convertToAsset` call to the `StataTokenV2`. 
 
-csUSDL
+csUSDL & v1.1
 The ERC4626 RateProvider fetches the rate of MetaMorpho Vault tokens in terms of the underlying asset. The exchange rate is provided via the conversion between totalAssets and totalSupply. The Morpho contract only determines the potential market parameters, assets, collaterals, beneficiary, owner, fee, and cooldown periods related to the vault curator. There are no entry or exit fees, and no time locks for users to deposit and withdraw from this vault. 
 
 ## Review Checklist: Bare Minimum Compatibility
@@ -82,6 +86,24 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
     - admin address: [ethereum:0x65bcf790Cb8ADf60D5f54eC2E10DE8C83886E0AE](https://etherscan.io/address/0x65bcf790Cb8ADf60D5f54eC2E10DE8C83886E0AE#code)
     - admin type: multisig
         - multisig threshold/signers: 3/17
+
+    #### Coinshift USDL (csUSDL) v1.1
+    The Metamorpho Vault
+    - Part of the rate computation relies of `totalAssets` being calculated. This function iterates over a list of Ids. This list of Ids can be changed by the Allocator role. The potential impact has not been thoroughly investigated. There are however protections in place to protect against invalid changes such as
+        - `revert ErrorsLib.DuplicateMarket(id);`
+        - `revert ErrorsLib.InvalidMarketRemovalNonZeroCap(id);`
+        - `revert ErrorsLib.PendingCap(id);`
+        - `ErrorsLib.InvalidMarketRemovalNonZeroSupply(id);`
+        - `ErrorsLib.InvalidMarketRemovalTimelockNotElapsed(id);`
+    - Also take into account the vaultAssetPriceFeed. This was investigated as part of the [review](./wUSDLPaxosRateProvider.md) with the upgradeable component: `wYBSV1` ([ethereum:0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559](https://etherscan.io/address/0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559#readProxyContract))
+    - admin address: [ethereum:0x60Be07b68214d49aF3Ec8fa89c7fc0970De0A94E](https://etherscan.io/address/0x60Be07b68214d49aF3Ec8fa89c7fc0970De0A94E#code)
+    - admin type: multisig
+        - multisig threshold/signers: 3/20
+    - upgradeable component: `YBSV1` ([ethereum:0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD](https://etherscan.io/address/0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD#code))
+    - admin address: [ethereum:0x65bcf790Cb8ADf60D5f54eC2E10DE8C83886E0AE](https://etherscan.io/address/0x65bcf790Cb8ADf60D5f54eC2E10DE8C83886E0AE#code)
+    - admin type: multisig
+        - multisig threshold/signers: 3/17
+
 
 ### Oracles
 - [ ] Price data is provided by an off-chain source (e.g., a Chainlink oracle, a multisig, or a network of nodes).

--- a/rate-providers/MorphoERC4626RateProviders.md
+++ b/rate-providers/MorphoERC4626RateProviders.md
@@ -55,7 +55,7 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
     - 0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D
     - 0x959d73CB5a1C1ad7EbCE3eC93FAD3b2f9a25432E
     #### v1.1 Steakhouse Coinshift USDC 
-    For [Steakhouse USDT](https://etherscan.io/address/0xB0926Cfc3aC047035b11d9afB85DC782E6D9d76A) some allocators are eoas.
+    For [Steakhouse csUSDC](https://etherscan.io/address/0xB0926Cfc3aC047035b11d9afB85DC782E6D9d76A) some allocators are eoas.
     - 0xfeed46c11F57B7126a773EeC6ae9cA7aE1C03C9a
     - 0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D
     - 0x29d4CDFee8F533af8529A9e1517b580E022874f7

--- a/rate-providers/MorphoERC4626RateProviders.md
+++ b/rate-providers/MorphoERC4626RateProviders.md
@@ -6,9 +6,9 @@
 - Deployed at:
     - Steakhouse USDC [ethereum:0xc81D60E39e065146c6dE186fFC5B39e4CA2189Cf](https://etherscan.io/address/0xc81D60E39e065146c6dE186fFC5B39e4CA2189Cf#code)
     - Steakhouse USDT [ethereum:0x50A72232c5370321aa78036BaDe8e9d5eB89cbAF](https://etherscan.io/address/0x50A72232c5370321aa78036BaDe8e9d5eB89cbAF#code)
-     - Steakhouse wUSDL - csUSDL [ethereum:0xbEc8a14233e68C02e803B999DbA3D0f9C5076394](https://etherscan.io/address/0xbEc8a14233e68C02e803B999DbA3D0f9C5076394#code)
+    - Steakhouse wUSDL - csUSDL [ethereum:0xbEc8a14233e68C02e803B999DbA3D0f9C5076394](https://etherscan.io/address/0xbEc8a14233e68C02e803B999DbA3D0f9C5076394#code)
     - Gauntlet Prime wETH [ethereum:0x0A25a2C62e3bA90F1e6F08666862df50cdAAB1F5](https://etherscan.io/address/0x0A25a2C62e3bA90F1e6F08666862df50cdAAB1F5#code)
-
+    - Steakhouse v1.1 USDC - csUSDC [ethereum:0xB0926Cfc3aC047035b11d9afB85DC782E6D9d76A](https://etherscan.io/address/0xB0926Cfc3aC047035b11d9afB85DC782E6D9d76A#code)
 
 - Audit report(s):
     - [Security Reviews & Formal Verifications](https://docs.morpho.org/security-reviews/)
@@ -54,6 +54,11 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
     For [Gauntlet Prime wETH](https://etherscan.io/address/0x2371e134e3455e0593363cBF89d3b6cf53740618) some allocators are eoas.
     - 0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D
     - 0x959d73CB5a1C1ad7EbCE3eC93FAD3b2f9a25432E
+    #### v1.1 Steakhouse Coinshift USDC 
+    For [Steakhouse USDT](https://etherscan.io/address/0xB0926Cfc3aC047035b11d9afB85DC782E6D9d76A) some allocators are eoas.
+    - 0xfeed46c11F57B7126a773EeC6ae9cA7aE1C03C9a
+    - 0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D
+    - 0x29d4CDFee8F533af8529A9e1517b580E022874f7
     
 ### Oracles
 - [ ] Price data is provided by an off-chain source (e.g., a Chainlink oracle, a multisig, or a network of nodes).
@@ -64,6 +69,6 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 - [ ] The Rate Provider is susceptible to donation attacks.
 
 ## Conclusion
-**Summary judgment: USABLE**
+**Summary judgment: v1.1 is USABLE**
 
 The Rate Providers should work well with Balancer pools. The underlying contracts have been audited and been in production for an extended period of time.

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1834,7 +1834,7 @@
       "asset": "0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330",
       "name": "ERC4626RateProvider",
       "summary": "safe",
-      "review": "./MorphoV1.1ERC4626RateProviders.md",
+      "review": "./MorphoERC4626RateProviders.md",
       "warnings": ["eoaUpgradeable"],
       "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
       "upgradeableComponents": [

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1791,7 +1791,7 @@
     "0xc81D60E39e065146c6dE186fFC5B39e4CA2189Cf": {
       "asset": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
       "name": "ERC4626RateProvider",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoERC4626RateProviders.md",
       "warnings": ["eoaUpgradeable"],
       "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
@@ -1805,7 +1805,7 @@
     "0x50A72232c5370321aa78036BaDe8e9d5eB89cbAF": {
       "asset": "0xbEef047a543E45807105E51A8BBEFCc5950fcfBa",
       "name": "ERC4626RateProvider",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoERC4626RateProviders.md",
       "warnings": ["eoaUpgradeable"],
       "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
@@ -1819,7 +1819,7 @@
     "0x0A25a2C62e3bA90F1e6F08666862df50cdAAB1F5": {
       "asset": "0x2371e134e3455e0593363cBF89d3b6cf53740618",
       "name": "ERC4626RateProvider",
-      "summary": "safe",
+      "summary": "unsafe",
       "review": "./MorphoERC4626RateProviders.md",
       "warnings": ["eoaUpgradeable"],
       "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
@@ -1827,6 +1827,20 @@
         {
           "entrypoint": "0x2371e134e3455e0593363cBF89d3b6cf53740618",
           "implementationReviewed": "0x2371e134e3455e0593363cBF89d3b6cf53740618"
+        }
+      ]
+    },
+    "0xB0926Cfc3aC047035b11d9afB85DC782E6D9d76A": {
+      "asset": "0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330",
+      "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./MorphoV1.1ERC4626RateProviders.md",
+      "warnings": ["eoaUpgradeable"],
+      "factory": "0xFC541f8d8c5e907E236C8931F0Df9F58e0C259Ec",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330",
+          "implementationReviewed": "0x7204B7Dbf9412567835633B6F00C3Edc3a8D6330"
         }
       ]
     },
@@ -1869,6 +1883,24 @@
     "0x9CC54cb63E61c7D5231c506e4206Eb459250D2A7": {
       "asset": "0xbEEFC01767ed5086f35deCb6C00e6C12bc7476C1",
       "name": "ERC4626RateProvider",
+      "summary": "safe",
+      "review": "./MarketRateTransformerRateProviders.md",
+      "warnings": [""],
+      "factory": "0xeC2C6184761ab7fE061130B4A7e3Da89c72F8395",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x7751E2F4b8ae93EF6B79d86419d42FE3295A4559",
+          "implementationReviewed": "0x2954c85e7e2b841d0e9a9fdcc09dac1274057d71"
+        },
+        {
+          "entrypoint": "0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD",
+          "implementationReviewed": "0x752d55d62a94658eac08eae42deda902b69b0e76"
+        }
+      ]
+    },
+    "0x9062a576D3e6Cf6999e99e405608063033c4CFF6": {
+      "asset": "0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1",
+      "name": "csUSDL-MORPHOv1.1",
       "summary": "safe",
       "review": "./MarketRateTransformerRateProviders.md",
       "warnings": [""],


### PR DESCRIPTION
This PR does the following:
- Marks current MetaMorpho vaults as unsafe due to the potential flash loan incompatibility. The rate providers remain "safe" technically, but will not ever be used. Feel free to remove this contracts from the registry completely if that is cleaner.
- Adds the new v1.1 vaults for a first review to take place. Please note audits are not available for these vaults, I will ask Morpho for them on Monday January 6th. 

Details:
New Morpho deployments of v1.1 vaults have been made initially by Steakhouse and Coinshift. These pertain to a new wUSDL deployment, and a new Coinshift branded csUSDC vault. Please review the rate providers, run fork tests for the vaults, and provide feedback as needed. @mkflow27

This version comes with key improvements:
- Automated bad debt realization is removed, making the vaults function similarly to an Aave instance. As a result, they can be safely rehypothecated and used in places that make their shares flashloanable.
- Curators can update vault names and symbols.
- Vaults can be deployed with timelock=0.