### PR TITLE
tETH-Arbitrum-CL-RP

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Rate Provider Factories for reference
 
 | Network    | ChainlinkRateProviderFactory               | ERC4626RateProviderFactory                 |
 | ---------- | ------------------------------------------ | ------------------------------------------ |
-| Arbitrum   | 0x1311Fbc9F60359639174c1e7cC2032DbDb5Cc4d1 | 0xe548a29631f9E49830bE8edc22d407b2D2915F31 |
+| Arbitrum   | 0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd | 0xe548a29631f9E49830bE8edc22d407b2D2915F31 |
 | Avalanche  | 0x76578ecf9a141296Ec657847fb45B0585bCDa3a6 | 0xfCe81cafe4b3F7e2263EFc2d907f488EBF2B238E |
 | Base       | 0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B | 0xEfD3aF73d3359014f3B864d37AC672A6d3D7ff1A |
 | Fraxtal    | 0x3f170631ed9821Ca51A59D996aB095162438DC10 | N/A                                        |

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -461,6 +461,15 @@
       "warnings": [],
       "factory": "0xe548a29631f9E49830bE8edc22d407b2D2915F31",
       "upgradeableComponents": []
+    },
+    "0x4FEFC8A9104464671E909c6470f3A08B71130659": {
+      "asset": "",
+      "name": "tETH / wstETH Rate Provider",
+      "summary": "safe",
+      "review": "./ChainLinkRateProvider.md",
+      "warnings": ["chainlink"],
+      "factory": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "upgradeableComponents": []
     }
   },
   "avalanche": {

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -463,7 +463,7 @@
       "upgradeableComponents": []
     },
     "0x4FEFC8A9104464671E909c6470f3A08B71130659": {
-      "asset": "",
+      "asset": "0xd09ACb80C1E8f2291862c4978A008791c9167003",
       "name": "tETH / wstETH Rate Provider",
       "summary": "safe",
       "review": "./ChainLinkRateProvider.md",


### PR DESCRIPTION
Adding in Chainlink rate provider for tETH / wstETH exchange rate. Also updating README due to wrong ChainlinkRateProviderFactory address in table.

tETH token address on Arbitrum to follow once deployed.

No need to merge this until address is provided. 