### PR TITLE
AaveRateTransformerFactory-Table-ezETH-Base-CL-RP

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Rate Provider Factories for reference
 | Sepolia    | 0xA8920455934Da4D853faac1f94Fe7bEf72943eF1 | N/A                                        |
 | zkEVM      | 0x4132f7AcC9dB7A6cF7BE2Dd3A9DC8b30C7E6E6c8 | N/A                                        |
 
+Rate Transformer Factories 
+Use these factories when an ERC4626 vault contains a yield bearing token to combine their resepctive rates of growth. This denominates the vault asset in the underlying for correlated pairs. For example Aave-wstETH pairing with Aave-wETH by denominating the assets in wETH.
+
+| Network    | AaveRateTransformerFactory                 | 
+| ---------- | -------------------------------------------|
+| Arbitrum   | 0xec2c6184761ab7fe061130b4a7e3da89c72f8395 | 
+| Base       | 0x4e185b1502fea7a06b63fdda6de38f92c9528566 |
+| Ethereum   | 0xec2c6184761ab7fe061130b4a7e3da89c72f8395 | 

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -704,6 +704,15 @@
       "warnings": ["chainlink"],
       "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B",
       "upgradeableComponents": []
+    },
+    "0x6ac3b3BeCE5AA61C6AB5d50ecd2D47b1f18ACe49": {
+      "asset": "0x2416092f143378750bb29b79ed961ab195cceea5",
+      "name": "ezETH Rate Provider",
+      "summary": "safe",
+      "review": "./ChainLinkRateProvider.md",
+      "warnings": ["chainlink"],
+      "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B",
+      "upgradeableComponents": []
     }
   },
   "ethereum": {

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -820,6 +820,7 @@
       "review": "./ChainLinkRateProvider.md",
       "warnings": ["chainlink"],
       "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B",
+      "upgradeableComponents": []
     },
     "0xc11082BbDBB8AaB12d0947EEAD2c8bc28E1b3B34": {
       "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",


### PR DESCRIPTION
Adding AaveRateTransofrmerFactory addresses to new table on ReadMe page.

Also adding ezETH Chainlink rate provider from resepctive factory on Base due to the it being utilized in a rate transformer.