### PR TITLE
Treehouse ETH CombinedRateProvider

### DIFF
--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -578,6 +578,15 @@
       "warnings": [""],
       "factory": "0xe548a29631f9E49830bE8edc22d407b2D2915F31",
       "upgradeableComponents": []
+    },
+    "0x998DE64cB90EdF3d205CFDB864E199fDA4d55710": {
+      "asset": "0xd09ACb80C1E8f2291862c4978A008791c9167003",
+      "name": "TreeHouseRateProvider",
+      "summary": "safe",
+      "review": "./ChainLinkRateProvider.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "avalanche": {

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -585,7 +585,7 @@
       "summary": "safe",
       "review": "./ChainLinkRateProvider.md",
       "warnings": [],
-      "factory": "",
+      "factory": "0x26dEc0e6a4249F28e0f16A1a79808bF9ba308310",
       "upgradeableComponents": []
     }
   },


### PR DESCRIPTION
Fixes #245

This rateProvider is a combination of 2 ChainLink price feed.

The factory should work by combining two rateProviders (which report an 18 decimal fixed point number) and scale it back to 18 decimals. 

This rp in my opinion does not require a separate review and it is just a combination of two ChainLink Rate providers.