### PR TITLE
Add cUSDO open eden rate provider review

### DIFF
--- a/rate-providers/cUSDOOpenEdenRateProvider.md
+++ b/rate-providers/cUSDOOpenEdenRateProvider.md
@@ -30,7 +30,7 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 - [x] Some other portion of the price pipeline is upgradeable (e.g., the token itself, an oracle, or some piece of a larger system that tracks the price).
     - upgradeable component: `cUSDO` ([ethereum:0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0](https://etherscan.io/address/0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0/))
     - admin address: [ethereum:0x5eaff7af80488033bc845709806d5fae5291eb88](https://etherscan.io/address/0x5eaff7af80488033bc845709806d5fae5291eb88)
-    - admin type: EOA
+    - admin type: EOA (MPC wallet)
 
 ### Oracles
 - [ ] Price data is provided by an off-chain source (e.g., a Chainlink oracle, a multisig, or a network of nodes).
@@ -45,7 +45,10 @@ This is a standard ERC-4626 implementation which is susceptible to donation atta
 ## Additional Findings
 To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
 
-## Conclusion
-**Summary judgment: UNUSABLE**
+ ### M-01: Opaque upgradeability mechanism
+The account allowed to upgrade the asset implemetation is an EOA (which according to OpenEden is an MPC wallet). It is not possibly to verify this onchain. LPs in pools which use this rate provider should be aware of it and verify if possible. For more information see: https://www.coinbase.com/en-br/learn/wallet/what-is-a-multi-party-computation-mpc-wallet
 
-Rate provider is a standard ERC4626RateProvider that relies on totalAssets/totalSupply, but cUSDO is upgradeable and managed by an EOA. We should be able to consider it USABLE in case cUSDO admin is updated to a multisig.
+## Conclusion
+**Summary judgment: USABLE**
+
+Rate provider is a standard ERC4626RateProvider that relies on totalAssets/totalSupply. `cUSDO` is upgradeable and managed by an MPC wallet which can't be validated onchain, so LPs should be aware of this and verify if possible.

--- a/rate-providers/cUSDOOpenEdenRateProvider.md
+++ b/rate-providers/cUSDOOpenEdenRateProvider.md
@@ -1,0 +1,51 @@
+# Rate Provider: cUSDO OpenEden Rate Provider
+
+## Details
+- Reviewed by: @brunoguerios
+- Checked by: @\<GitHub handle of secondary reviewer\>
+- Deployed at:
+    - [ethereum:0x05E956cb3407b1B22F4ed8568F3C28644Da28B85](https://etherscan.io/address/0x05E956cb3407b1B22F4ed8568F3C28644Da28B85#readContract)
+- Audit report(s):
+    - [Protocol Audits](https://docs.openeden.com/treasury-bills-vault/risks)
+    - [ChainSecurity Audit](https://github.com/OpenEdenHQ/audit-reports/blob/main/ChainSecurity/ChainSecurity_OpenEden_USDO_audit.pdf)
+    - [Additional Active Audit](https://audits.hacken.io/openeden/)
+
+## Context
+Rate provider is a standard ERC4626RateProvider that relies on totalAssets/totalSupply.
+
+## Review Checklist: Bare Minimum Compatibility
+Each of the items below represents an absolute requirement for the Rate Provider. If any of these is unchecked, the Rate Provider is unfit to use.
+
+- [x] Implements the [`IRateProvider`](https://github.com/balancer/balancer-v2-monorepo/blob/bc3b3fee6e13e01d2efe610ed8118fdb74dfc1f2/pkg/interfaces/contracts/pool-utils/IRateProvider.sol) interface.
+- [x] `getRate` returns an 18-decimal fixed point number (i.e., 1 == 1e18) regardless of underlying token decimals.
+
+## Review Checklist: Common Findings
+Each of the items below represents a common red flag found in Rate Provider contracts.
+
+If none of these is checked, then this might be a pretty great Rate Provider! If any of these is checked, we must thoroughly elaborate on the conditions that lead to the potential issue. Decision points are not binary; a Rate Provider can be usable despite these boxes being checked. A check simply indicates that thorough vetting is required in a specific area, and this vetting should be used to inform a holistic analysis of the Rate Provider.
+
+### Administrative Privileges
+- [ ] The Rate Provider is upgradeable (e.g., via a proxy architecture or an `onlyOwner` function that updates the price source address).
+
+- [x] Some other portion of the price pipeline is upgradeable (e.g., the token itself, an oracle, or some piece of a larger system that tracks the price).
+    - upgradeable component: `cUSDO` ([ethereum:0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0](https://etherscan.io/address/0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0/))
+    - admin address: [ethereum:0x5eaff7af80488033bc845709806d5fae5291eb88](https://etherscan.io/address/0x5eaff7af80488033bc845709806d5fae5291eb88)
+    - admin type: EOA
+
+### Oracles
+- [ ] Price data is provided by an off-chain source (e.g., a Chainlink oracle, a multisig, or a network of nodes).
+
+- [ ] Price data is expected to be volatile (e.g., because it represents an open market price instead of a (mostly) monotonically increasing price).
+
+### Common Manipulation Vectors
+- [x] The Rate Provider is susceptible to donation attacks.
+
+This is a standard ERC-4626 implementation which is susceptible to donation attacks via live `balanceOf()` queries.
+
+## Additional Findings
+To save time, we do not bother pointing out low-severity/informational issues or gas optimizations (unless the gas usage is particularly egregious). Instead, we focus only on high- and medium-severity findings which materially impact the contract's functionality and could harm users.
+
+## Conclusion
+**Summary judgment: UNUSABLE**
+
+Rate provider is a standard ERC4626RateProvider that relies on totalAssets/totalSupply, but cUSDO is upgradeable and managed by an EOA. We should be able to consider it USABLE in case cUSDO admin is updated to a multisig.

--- a/rate-providers/cUSDOOpenEdenRateProvider.md
+++ b/rate-providers/cUSDOOpenEdenRateProvider.md
@@ -2,7 +2,7 @@
 
 ## Details
 - Reviewed by: @brunoguerios
-- Checked by: @\<GitHub handle of secondary reviewer\>
+- Checked by: @mkflow27
 - Deployed at:
     - [ethereum:0x05E956cb3407b1B22F4ed8568F3C28644Da28B85](https://etherscan.io/address/0x05E956cb3407b1B22F4ed8568F3C28644Da28B85#readContract)
 - Audit report(s):

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -2561,7 +2561,7 @@
     "0x05E956cb3407b1B22F4ed8568F3C28644Da28B85": {
       "asset": "0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0",
       "name": "cUSDO OpenEden Rate Provider",
-      "summary": "unsafe",
+      "summary": "safe",
       "review": "./cUSDOOpenEdenRateProvider.md",
       "warnings": ["donation", "eoaUpgradeable"],
       "factory": "",

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -2557,6 +2557,20 @@
           "implementationReviewed": "0xD1A622566F277AA76c3C47A30469432AAec95E38"
         }
       ]
+    },
+    "0x05E956cb3407b1B22F4ed8568F3C28644Da28B85": {
+      "asset": "0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0",
+      "name": "cUSDO OpenEden Rate Provider",
+      "summary": "unsafe",
+      "review": "./cUSDOOpenEdenRateProvider.md",
+      "warnings": ["donation", "eoaUpgradeable"],
+      "factory": "",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0xad55aebc9b8c03fc43cd9f62260391c13c23e7c0",
+          "implementationReviewed": "0x7a3e55e2c23ab6adc12accf1075b91c174ee0102"
+        }
+      ]
     }
   },
   "fantom": {


### PR DESCRIPTION
Close #267 

For context, it's standard erc4626 rate provider, so doesn't seem to have anything "unusual" worth highlighting.
The only bit of information that wasn't as trivial to find was the owner of the asset's proxy implementation.
I found it by tracking the `RoleGranted` event which is represented by the following topic0: `0x2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d`
You'll find that all roles are granted to the same EOA reported in the review.