### PR TITLE
aEURC-Base-RateTransformer

### DIFF
--- a/erc4626/StatATokenV2Review.md
+++ b/erc4626/StatATokenV2Review.md
@@ -21,6 +21,7 @@
     - [base:0x5e8B674127B321DC344c078e58BBACc3f3008962](https://basescan.org/address/0x5e8B674127B321DC344c078e58BBACc3f3008962#readProxyContract)
     - [base:0x74D4D1D440c9679b1013999Bd91507eAa2fff651](https://basescan.org/address/0x74D4D1D440c9679b1013999Bd91507eAa2fff651#readProxyContract)
     - [base:0xF8F10f39116716e89498c1c5E94137ADa11b2BC7](https://basescan.org/address/0xF8F10f39116716e89498c1c5E94137ADa11b2BC7#readProxyContract)
+    - [base:0x729F75Aff28c726e32403e80cef2aFb518CFbfa7](https://basescan.org/address/0x729F75Aff28c726e32403e80cef2aFb518CFbfa7#readProxyContract)
     - [arbitrum:0x4cE13a79f45C1Be00BdABD38B764aC28C082704E](https://arbiscan.io/address/0x4cE13a79f45C1Be00BdABD38B764aC28C082704E#readProxyContract)
     - [arbitrum:0xD9E3Ef2c12de90E3b03F7b7E3964956a71920d40](https://arbiscan.io/address/0xD9E3Ef2c12de90E3b03F7b7E3964956a71920d40#readProxyContract)
     - [arbitrum:0x52Dc1FEeFA4f9a99221F93D79da46Ae89b8c0967](https://arbiscan.io/address/0x52Dc1FEeFA4f9a99221F93D79da46Ae89b8c0967)
@@ -170,6 +171,12 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
 
     #### Wrapped Aave Base ezETH - 0xF8F10f39116716e89498c1c5E94137ADa11b2BC7
     - upgradeable component: `StataTokenV2` ([base:0xF8F10f39116716e89498c1c5E94137ADa11b2BC7](https://basescan.org/address/0xF8F10f39116716e89498c1c5E94137ADa11b2BC7))
+        - admin address: [base:0x9390B1735def18560c509E2d0bc090E9d6BA257a](https://basescan.org/address/0x9390B1735def18560c509E2d0bc090E9d6BA257a)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
+         
+    #### Wrapped Aave Base EURC - 0x729F75Aff28c726e32403e80cef2aFb518CFbfa7
+    - upgradeable component: `StataTokenV2` ([base:0x729F75Aff28c726e32403e80cef2aFb518CFbfa7](https://basescan.org/address/0x729F75Aff28c726e32403e80cef2aFb518CFbfa7#readProxyContract))
         - admin address: [base:0x9390B1735def18560c509E2d0bc090E9d6BA257a](https://basescan.org/address/0x9390B1735def18560c509E2d0bc090E9d6BA257a)
         - admin type: Aave governance system.
             - multisig timelock? YES: 24 hours.

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -282,6 +282,16 @@
       "useUnderlyingForAddRemove": true,
       "useWrappedForAddRemove": true
     },
+    "0x729F75Aff28c726e32403e80cef2aFb518CFbfa7": {
+      "asset": "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
+      "name": "Wrapped Aave Base EURC",
+      "summary": "safe",
+      "review": "./StatATokenV2Review.md",
+      "warnings": [],
+      "canUseBufferForSwaps": true,
+      "useUnderlyingForAddRemove": true,
+      "useWrappedForAddRemove": true
+    },
     "0x9272d6153133175175bc276512b2336be3931ce9": {
       "asset": "0x4200000000000000000000000000000000000006",
       "name": "fluid weth",

--- a/rate-providers/MarketRateTransformerRateProviders.md
+++ b/rate-providers/MarketRateTransformerRateProviders.md
@@ -44,6 +44,10 @@
         - ERC4626RateProvider: Fluid Wrapped Staked Eth 
         - ERC4626Vault's `asset` rate provider: Fluid's custom rate provider
 
+    - Wrapped Aave Base EURC [base:0xd9B86d5B91782c86bfBC72d313ADaf1E06aAD79E](https://basescan.org/address/0xd9B86d5B91782c86bfBC72d313ADaf1E06aAD79E#readContract)
+        - ERC4626RateProvider: Wrapped Aave Base EURC 
+        - ERC4626Vault's `asset` rate provider: Chainlink EURC to USD
+
 - Audit report(s):
     - [Formal Verification Report For StaticAToken](https://github.com/aave-dao/aave-v3-origin/blob/067d29eb75115179501edc4316d125d9773f7928/audits/11-09-2024_Certora_StataTokenV2.pdf)
     - [Security Reviews & Formal Verifications](https://docs.morpho.org/security-reviews/)
@@ -216,6 +220,16 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
         - admin type: Aave governance system.
             - multisig timelock? YES: 24 hours.
 
+    #### Wrapped Aave Base EURC
+    - [base:0x729F75Aff28c726e32403e80cef2aFb518CFbfa7](https://basescan.org/address/0x729F75Aff28c726e32403e80cef2aFb518CFbfa7#readContract)
+        - upgradeable component: `StataTokenV2` ([base:0xF8F10f39116716e89498c1c5E94137ADa11b2BC7](https://basescan.org/address/0xF8F10f39116716e89498c1c5E94137ADa11b2BC7#readProxyContract))
+        - admin address: [base:0x9390B1735def18560c509E2d0bc090E9d6BA257a](https://basescan.org/address/0x9390B1735def18560c509E2d0bc090E9d6BA257a)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
+        - upgradeable component: `L2PoolInstance` ([base:0xA238Dd80C259a72e81d7e4664a9801593F98d1c5](https://basescan.org/address/0xA238Dd80C259a72e81d7e4664a9801593F98d1c5))
+        - admin address: [base:0x9390B1735def18560c509E2d0bc090E9d6BA257a](https://basescan.org/address/0x9390B1735def18560c509E2d0bc090E9d6BA257a)
+        - admin type: Aave governance system.
+            - multisig timelock? YES: 24 hours.
 
 ### Oracles
 - [x] Price data is provided by an off-chain source (e.g., a Chainlink oracle, a multisig, or a network of nodes).
@@ -232,7 +246,8 @@ If none of these is checked, then this might be a pretty great Rate Provider! If
     - The ERC4626 Vault utilises a Chainlink Rate Provider at [base:0xCd9e3fb32c8F258555b8292531112bBb5B87E2F4](https://arbiscan.io/address/0xCd9e3fb32c8F258555b8292531112bBb5B87E2F4#code)
     #### Wrapped Aave Arbitrum wstETH 
     - The ERC4626 Vault utilises a Chainlink Rate Provider at [base:0xf7c5c26B574063e7b098ed74fAd6779e65E3F836](https://arbiscan.io/address/0xf7c5c26B574063e7b098ed74fAd6779e65E3F836)
-
+    #### Wrapped Aave Base EURC
+    - The ERC4626 Vault utilises a Chainlink Rate Provider at [base:0xf0527f3e8E4Ed72A27055DB703AD30d40f531281](https://basescan.org/address/0xf0527f3e8E4Ed72A27055DB703AD30d40f531281)
 
 - [ ] Price data is expected to be volatile (e.g., because it represents an open market price instead of a (mostly) monotonically increasing price).
 

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1108,7 +1108,7 @@
       "upgradeableComponents": []
     },
     "0xd9B86d5B91782c86bfBC72d313ADaf1E06aAD79E": {
-      "asset": "0x729F75Aff28c726e32403e80cef2aFb518CFbfa7",
+      "asset": "0xdBB41Da7dE45729857A09baaF98D1e9b0b1A8740",
       "name": "aEURC to USD AaveMarketRateTransformer",
       "summary": "safe",
       "review": "./MarketRateTransformerRateProviders.md",

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -1106,6 +1106,15 @@
       "warnings": ["chainlink"],
       "factory": "0x0A973B6DB16C2ded41dC91691Cc347BEb0e2442B",
       "upgradeableComponents": []
+    },
+    "0xd9B86d5B91782c86bfBC72d313ADaf1E06aAD79E": {
+      "asset": "0x729F75Aff28c726e32403e80cef2aFb518CFbfa7",
+      "name": "aEURC to USD AaveMarketRateTransformer",
+      "summary": "safe",
+      "review": "./MarketRateTransformerRateProviders.md",
+      "warnings": [],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "ethereum": {


### PR DESCRIPTION
Adds rate transformer rate provider contract for EURC on aave market. To be paired aEURC-aGHO with yield exemption on Euro portion.

Chainlink EUR:USD combined with ERC4626 rate from Aave.