### PR TITLE
change to new mev cluster

### DIFF
--- a/erc4626/EulerVault.md
+++ b/erc4626/EulerVault.md
@@ -4,9 +4,7 @@
 - Reviewed by: @franzns
 - Checked by: @danielmkm
 - Deployed at:
-    - [sonic:0x0806af1762Bdd85B167825ab1a64E31CF9497038](https://sonicscan.org/address/0x0806af1762Bdd85B167825ab1a64E31CF9497038#code)
-    - [sonic:0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b](https://sonicscan.org/address/0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b#code)
-    - [sonic:0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A](https://sonicscan.org/address/0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A#code)
+    - [sonic:0x90a804D316A06E00755444D56b9eF52e5C4F4D73](https://sonicscan.org/address/0x90a804D316A06E00755444D56b9eF52e5C4F4D73#code)
 - Audit report(s):
     - [EVK Audits](https://docs.euler.finance/security/audits)
 

--- a/erc4626/EulerVault.md
+++ b/erc4626/EulerVault.md
@@ -5,6 +5,7 @@
 - Checked by: @danielmkm
 - Deployed at:
     - [sonic:0x90a804D316A06E00755444D56b9eF52e5C4F4D73](https://sonicscan.org/address/0x90a804D316A06E00755444D56b9eF52e5C4F4D73#code)
+    - [sonic:0x6832F3090867449c058e1e3088E552E12AB18F9E](https://sonicscan.org/address/0x6832F3090867449c058e1e3088E552E12AB18F9E#code)
 - Audit report(s):
     - [EVK Audits](https://docs.euler.finance/security/audits)
 

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -818,29 +818,9 @@
       "useUnderlyingForAddRemove": true,
       "useWrappedForAddRemove": true
     },
-    "0x0806af1762Bdd85B167825ab1a64E31CF9497038": {
-      "asset": "0x3bcE5CB273F0F148010BbEa2470e7b5df84C7812",
-      "name": "EVK Vault escETH-2",
-      "summary": "safe",
-      "review": "./EulerVault.md",
-      "warnings": [],
-      "canUseBufferForSwaps": true,
-      "useUnderlyingForAddRemove": true,
-      "useWrappedForAddRemove": true
-    },
-    "0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b": {
-      "asset": "0x50c42dEAcD8Fc9773493ED674b675bE577f2634b",
-      "name": "EVK Vault eWETH-1",
-      "summary": "safe",
-      "review": "./EulerVault.md",
-      "warnings": [],
-      "canUseBufferForSwaps": true,
-      "useUnderlyingForAddRemove": true,
-      "useWrappedForAddRemove": true
-    },
-    "0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A": {
+    "0x90a804D316A06E00755444D56b9eF52e5C4F4D73": {
       "asset": "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38",
-      "name": "EVK Vault ewS-2",
+      "name": "EVK Vault ewS-5",
       "summary": "safe",
       "review": "./EulerVault.md",
       "warnings": [],

--- a/erc4626/registry.json
+++ b/erc4626/registry.json
@@ -827,6 +827,16 @@
       "canUseBufferForSwaps": true,
       "useUnderlyingForAddRemove": true,
       "useWrappedForAddRemove": true
+    },
+    "0x6832F3090867449c058e1e3088E552E12AB18F9E": {
+      "asset": "0xE5DA20F15420aD15DE0fa650600aFc998bbE3955",
+      "name": "EVK Vault estS-5",
+      "summary": "safe",
+      "review": "./EulerVault.md",
+      "warnings": [],
+      "canUseBufferForSwaps": true,
+      "useUnderlyingForAddRemove": true,
+      "useWrappedForAddRemove": true
     }
   },
   "avalanche": {

--- a/rate-providers/EulerWrappedRateprovider.md
+++ b/rate-providers/EulerWrappedRateprovider.md
@@ -5,6 +5,7 @@
 - Checked by: @danielmkm
 - Deployed at:
     - [sonic:0xad597fce59dbbd13bcd5bcc1a6fd654acfa92eff](https://sonicscan.org/address/0xad597fce59dbbd13bcd5bcc1a6fd654acfa92eff#code)
+    - [sonic:0x7a5a8bece4c24c0c903f6adbc866a42c1799926d](https://sonicscan.org/address/0x7a5a8bece4c24c0c903f6adbc866a42c1799926d#code)
 - Audit report(s):
     - [EVK Audits](https://docs.euler.finance/security/audits)
 

--- a/rate-providers/EulerWrappedRateprovider.md
+++ b/rate-providers/EulerWrappedRateprovider.md
@@ -4,9 +4,7 @@
 - Reviewed by: @franzns
 - Checked by: @danielmkm
 - Deployed at:
-    - [sonic:0x631c46a198d9fc553fd0790ad34972a96667feb9](https://sonicscan.org/address/0x631c46a198d9fc553fd0790ad34972a96667feb9#code)
-    - [sonic:0xb5a7ab4d068a37cbede6097218bd089c39784528](https://sonicscan.org/address/0xb5a7ab4d068a37cbede6097218bd089c39784528#code)
-    - [sonic:0x042cbb7aca4470aeaf10195a433a973f76540b50](https://sonicscan.org/address/0x042cbb7aca4470aeaf10195a433a973f76540b50#code)
+    - [sonic:0xad597fce59dbbd13bcd5bcc1a6fd654acfa92eff](https://sonicscan.org/address/0xad597fce59dbbd13bcd5bcc1a6fd654acfa92eff#code)
 - Audit report(s):
     - [EVK Audits](https://docs.euler.finance/security/audits)
 

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -4107,6 +4107,20 @@
         }
       ]
     },
+    "0x7a5a8bece4c24c0c903f6adbc866a42c1799926d": {
+      "asset": "0x6832F3090867449c058e1e3088E552E12AB18F9E",
+      "name": "Euler Vault estS-5 Rateprovider",
+      "summary": "safe",
+      "review": "./EulerWrappedRateprovider.md",
+      "warnings": [""],
+      "factory": "0x00de97829d01815346e58372be55aefd84ca2457",
+      "upgradeableComponents": [
+        {
+          "entrypoint": "0x6832F3090867449c058e1e3088E552E12AB18F9E",
+          "implementationReviewed": "0x11f95aaa59f1ad89576c61e3c9cd24df1fdcf46f"
+        }
+      ]
+    },
     "0x871A101Dcf22fE4fE37be7B654098c801CBA1c88": {
       "asset": "0x871A101Dcf22fE4fE37be7B654098c801CBA1c88",
       "name": "Beefy-Escrowed Sonic Rateprovider",

--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -4093,44 +4093,16 @@
       "factory": "0x00de97829d01815346e58372be55aefd84ca2457",
       "upgradeableComponents": []
     },
-    "0x631c46a198d9fc553fd0790ad34972a96667feb9": {
-      "asset": "0x0806af1762Bdd85B167825ab1a64E31CF9497038",
-      "name": "Euler EVK Vault escETH-2 Rateprovider",
+    "0xad597fce59dbbd13bcd5bcc1a6fd654acfa92eff": {
+      "asset": "0x90a804D316A06E00755444D56b9eF52e5C4F4D73",
+      "name": "Euler Vault eWS-5 Rateprovider",
       "summary": "safe",
       "review": "./EulerWrappedRateprovider.md",
       "warnings": [""],
       "factory": "0x00de97829d01815346e58372be55aefd84ca2457",
       "upgradeableComponents": [
         {
-          "entrypoint": "0x0806af1762Bdd85B167825ab1a64E31CF9497038",
-          "implementationReviewed": "0x11f95aaa59f1ad89576c61e3c9cd24df1fdcf46f"
-        }
-      ]
-    },
-    "0xb5a7ab4d068a37cbede6097218bd089c39784528": {
-      "asset": "0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b",
-      "name": "Euler Vault eWETH-1 Rateprovider",
-      "summary": "safe",
-      "review": "./EulerWrappedRateprovider.md",
-      "warnings": [""],
-      "factory": "0x00de97829d01815346e58372be55aefd84ca2457",
-      "upgradeableComponents": [
-        {
-          "entrypoint": "0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b",
-          "implementationReviewed": "0x11f95aaa59f1ad89576c61e3c9cd24df1fdcf46f"
-        }
-      ]
-    },
-    "0x042cbb7aca4470aeaf10195a433a973f76540b50": {
-      "asset": "0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A",
-      "name": "Euler Vault eWS-2 Rateprovider",
-      "summary": "safe",
-      "review": "./EulerWrappedRateprovider.md",
-      "warnings": [""],
-      "factory": "0x00de97829d01815346e58372be55aefd84ca2457",
-      "upgradeableComponents": [
-        {
-          "entrypoint": "0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A",
+          "entrypoint": "0x90a804D316A06E00755444D56b9eF52e5C4F4D73",
           "implementationReviewed": "0x11f95aaa59f1ad89576c61e3c9cd24df1fdcf46f"
         }
       ]


### PR DESCRIPTION
The old cluster has socialized debt while the new one has it disabled.

Hence the old one needs to be removed as they are not safe. Adding the new wS market. https://sonicscan.org/address/0x90a804D316A06E00755444D56b9eF52e5C4F4D73#readProxyContract#F27 is set to 1 which is turning off the socialized debt