### PR TITLE
EURC-RateProvider-CL-Mainnet

### DIFF
--- a/rate-providers/registry.json
+++ b/rate-providers/registry.json
@@ -3082,6 +3082,15 @@
       "warnings": [],
       "factory": "",
       "upgradeableComponents": []
+    },
+    "0xe843ba80bd133fc1a8c0ce2e9e2962b9499cbeb4": {
+      "asset": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+      "name": "EURO Rate Provider",
+      "summary": "safe",
+      "review": "./ChainLinkRateProvider.md",
+      "warnings": ["chainlink"],
+      "factory": "",
+      "upgradeableComponents": []
     }
   },
   "fantom": {


### PR DESCRIPTION
Conduit, Forex project working with Circle and Monerium assets primarily interested in deploying a stable surge pool using the Euro CL oracle feed on ETH mainnet.

This is the rate provider from the CL factory. Adding to registry to be whitelisted on the front end.